### PR TITLE
Fix employee password handling and visa quota

### DIFF
--- a/pagasys/models.py
+++ b/pagasys/models.py
@@ -235,7 +235,8 @@ class Employee(AbstractUser):
             raise ValidationError(
                 "Employee must belong to exactly one of department or project"
             )
-        if self.trade_license.employees.count() >= self.trade_license.max_visas:
+        current = self.trade_license.employees.exclude(pk=self.pk).count()
+        if current >= self.trade_license.max_visas:
             raise ValidationError("Visa quota reached")
         if self.designation and self.designation.company != self.trade_license.company:
             raise ValidationError("Designation must match company")
@@ -253,3 +254,17 @@ class Employee(AbstractUser):
 
     def __str__(self) -> str:
         return f"{self.first_name} {self.last_name}"
+
+    def save(self, *args, **kwargs):
+        """Ensure visa quota checks are performed atomically."""
+        from django.db import transaction
+
+        with transaction.atomic():
+            lic = (
+                TradeLicense.objects.select_for_update()
+                .get(pk=self.trade_license_id)
+            )
+            current = lic.employees.exclude(pk=self.pk).count()
+            if current >= lic.max_visas:
+                raise ValidationError("Visa quota reached")
+            super().save(*args, **kwargs)

--- a/pagasys/serializers.py
+++ b/pagasys/serializers.py
@@ -160,6 +160,24 @@ class EmployeeSerializer(serializers.ModelSerializer):
         }
 
     def validate(self, attrs):
-        instance = Employee(**attrs)
+        if self.instance is not None:
+            data = {f.name: getattr(self.instance, f.name) for f in Employee._meta.fields}
+            data.update(attrs)
+            instance = Employee(**data)
+        else:
+            instance = Employee(**attrs)
         instance.clean()
         return attrs
+
+    def create(self, validated_data):
+        password = validated_data.pop('password')
+        user = Employee.objects.create_user(password=password, **validated_data)
+        return user
+
+    def update(self, instance, validated_data):
+        password = validated_data.pop('password', None)
+        user = super().update(instance, validated_data)
+        if password:
+            user.set_password(password)
+            user.save()
+        return user

--- a/pagasys/tests/test_employee_serializer.py
+++ b/pagasys/tests/test_employee_serializer.py
@@ -1,0 +1,50 @@
+from django.test import TestCase
+
+from pagasys.models import Company, Branch, Department, TradeLicense, Employee
+from pagasys.serializers import EmployeeSerializer
+
+
+class EmployeeSerializerPasswordTests(TestCase):
+    def setUp(self):
+        self.company = Company.objects.create(name="Co")
+        self.branch = Branch.objects.create(company=self.company, name="B1")
+        self.department = Department.objects.create(branch=self.branch, name="D1")
+        self.license = TradeLicense.objects.create(
+            company=self.company,
+            license_no="L1",
+            issued_date="2024-01-01",
+            expiry_date="2025-01-01",
+            max_visas=5,
+        )
+        self.license.branches.set([self.branch])
+
+    def test_password_hashed_on_create(self):
+        data = {
+            "username": "u1",
+            "password": "secret",
+            "trade_license": self.license.id,
+            "department": self.department.id,
+            "hire_date": "2024-01-02",
+            "employment_type": "permanent",
+        }
+        ser = EmployeeSerializer(data=data)
+        self.assertTrue(ser.is_valid(), ser.errors)
+        emp = ser.save()
+        self.assertNotEqual(emp.password, "secret")
+        self.assertTrue(emp.check_password("secret"))
+
+    def test_password_hashed_on_update(self):
+        emp = Employee.objects.create_user(
+            username="u2",
+            password="old",
+            trade_license=self.license,
+            department=self.department,
+            hire_date="2024-01-02",
+            employment_type="permanent",
+        )
+        ser = EmployeeSerializer(emp, data={"password": "new"}, partial=True)
+        self.assertTrue(ser.is_valid(), ser.errors)
+        emp = ser.save()
+        self.assertTrue(emp.check_password("new"))
+
+


### PR DESCRIPTION
## Summary
- ensure visa quota checks are atomic by locking `TradeLicense` rows in `Employee.save`
- hash passwords in `EmployeeSerializer` during create and update
- allow partial updates by merging instance data during validation
- add tests verifying password hashing behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68813ba1e110832db2f0311c74db6d3a