### PR TITLE
Handle M2M in bulk ops with tests

### DIFF
--- a/pagasys/serializers.py
+++ b/pagasys/serializers.py
@@ -111,7 +111,12 @@ class TradeLicenseSerializer(serializers.ModelSerializer):
 
     def validate(self, attrs):
         attrs = super().validate(attrs)
-        instance = TradeLicense(**attrs)
+        if self.instance is not None:
+            data = {f.name: getattr(self.instance, f.name) for f in TradeLicense._meta.fields}
+            data.update({k: v for k, v in attrs.items() if k != 'branches'})
+        else:
+            data = {k: v for k, v in attrs.items() if k != 'branches'}
+        instance = TradeLicense(**data)
         instance.clean()
         return attrs
 

--- a/pagasys/tests/test_bulk_other_models.py
+++ b/pagasys/tests/test_bulk_other_models.py
@@ -189,3 +189,109 @@ class OtherBulkActionsTests(TestCase):
             },
         ]
         self._run_crud_flow("employees", Employee, create, updates)
+
+    def test_license_bulk_create_with_branches(self):
+        """Creating licenses with branch relations works in bulk."""
+        payload = [
+            {
+                "company": self.company.id,
+                "branches": [self.branch.id],
+                "license_no": "L3",
+                "issued_date": "2024-01-01",
+                "expiry_date": "2025-01-01",
+                "max_visas": 5,
+            },
+            {
+                "company": self.company.id,
+                "branches": [self.branch.id],
+                "license_no": "L4",
+                "issued_date": "2024-01-01",
+                "expiry_date": "2025-01-01",
+                "max_visas": 6,
+            },
+        ]
+        res = self.client.post("/api/licenses/bulk/", payload, format="json")
+        self.assertEqual(res.status_code, 201)
+        ids = [obj["id"] for obj in res.data["created"]]
+        self.assertEqual(len(ids), 2)
+        for lic_id in ids:
+            lic = TradeLicense.objects.get(id=lic_id)
+            self.assertEqual(list(lic.branches.all()), [self.branch])
+
+    def test_license_bulk_update_branches(self):
+        """Updating license branch relations works in bulk."""
+        lic = TradeLicense.objects.create(
+            company=self.company,
+            license_no="L5",
+            issued_date="2024-01-01",
+            expiry_date="2025-01-01",
+            max_visas=5,
+        )
+        lic.branches.set([self.branch])
+        new_branch = Branch.objects.create(company=self.company, name="B2")
+
+        payload = [
+            {
+                "id": lic.id,
+                "branches": [new_branch.id],
+                "max_visas": 10,
+            }
+        ]
+        res = self.client.patch("/api/licenses/bulk-update/", payload, format="json")
+        self.assertEqual(res.status_code, 200)
+        lic.refresh_from_db()
+        self.assertEqual(list(lic.branches.all()), [new_branch])
+
+    def test_license_bulk_create_invalid_branch(self):
+        """Invalid branch references should not create licenses."""
+        payload = [
+            {
+                "company": self.company.id,
+                "branches": [9999],
+                "license_no": "BAD1",
+                "issued_date": "2024-01-01",
+                "expiry_date": "2025-01-01",
+                "max_visas": 5,
+            }
+        ]
+        res = self.client.post("/api/licenses/bulk/", payload, format="json")
+        self.assertEqual(res.status_code, 207)
+        self.assertEqual(res.data["created"], [])
+        self.assertEqual(TradeLicense.objects.filter(license_no="BAD1").count(), 0)
+        self.assertIn("branches", res.data["errors"][0]["errors"])
+
+    def test_license_bulk_create_duplicate_number(self):
+        """Duplicate license numbers trigger partial failure without persistence."""
+        existing = TradeLicense.objects.create(
+            company=self.company,
+            license_no="DUPE",
+            issued_date="2024-01-01",
+            expiry_date="2025-01-01",
+            max_visas=5,
+        )
+        existing.branches.set([self.branch])
+
+        payload = [
+            {
+                "company": self.company.id,
+                "branches": [self.branch.id],
+                "license_no": "DUPE2",
+                "issued_date": "2024-01-01",
+                "expiry_date": "2025-01-01",
+                "max_visas": 5,
+            },
+            {
+                "company": self.company.id,
+                "branches": [self.branch.id],
+                "license_no": "DUPE",
+                "issued_date": "2024-01-01",
+                "expiry_date": "2025-01-01",
+                "max_visas": 5,
+            },
+        ]
+        res = self.client.post("/api/licenses/bulk/", payload, format="json")
+        self.assertEqual(res.status_code, 207)
+        self.assertEqual(len(res.data["created"]), 1)
+        self.assertEqual(TradeLicense.objects.filter(license_no="DUPE").count(), 1)
+        err_keys = res.data["errors"][0]["errors"].keys()
+        self.assertTrue("non_field_errors" in err_keys or "license_no" in err_keys)

--- a/pagasys/views.py
+++ b/pagasys/views.py
@@ -7,7 +7,7 @@ from drf_spectacular.utils import extend_schema, extend_schema_view
 from django_filters.rest_framework import DjangoFilterBackend
 from django_filters import rest_framework as filters
 
-from django.db import IntegrityError, models
+from django.db import IntegrityError, models, transaction
 
 from .permissions import CustomObjectPermission
 from .utils import scope_queryset
@@ -51,7 +51,8 @@ class BulkCreateMixin:
             ser = self.get_serializer(data=item)
             if ser.is_valid():
                 try:
-                    created_objs.append(ser.save())
+                    with transaction.atomic():
+                        created_objs.append(ser.save())
                 except IntegrityError as exc:
                     errors.append({"data": item, "errors": {"non_field_errors": [str(exc)]}})
             else:
@@ -92,7 +93,8 @@ class BulkUpdateMixin:
             ser = self.get_serializer(instance, data=item, partial=True)
             if ser.is_valid():
                 try:
-                    updated_objs.append(ser.save())
+                    with transaction.atomic():
+                        updated_objs.append(ser.save())
                 except IntegrityError as exc:
                     errors.append({"data": item, "errors": {"non_field_errors": [str(exc)]}})
             else:


### PR DESCRIPTION
## Summary
- ensure bulk mixins wrap `ser.save()` in a transaction
- adjust `TradeLicenseSerializer.validate` for partial updates
- add extensive tests covering bulk create/update with branches

## Testing
- `SECRET_KEY=secret DEBUG=1 DATABASE_URL=sqlite:///db.sqlite3 pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688146fb1e60832d8957c5fae20e6077