### PR TITLE
Fix DRF pagination warning

### DIFF
--- a/pagasys/models.py
+++ b/pagasys/models.py
@@ -125,6 +125,7 @@ class Department(models.Model):
 
     class Meta:
         verbose_name_plural = "departments"
+        ordering = ["id"]
 
     def __str__(self) -> str:
         return self.name


### PR DESCRIPTION
## Summary
- set a default ordering for `Department` objects

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68814e423c7c832d9ace9ae569e6b173