### PR TITLE
Add punch reason to OpenAPI schema

### DIFF
--- a/tests/swagger/openapi.yaml
+++ b/tests/swagger/openapi.yaml
@@ -13110,8 +13110,12 @@ components:
           type: boolean
         roster_fallback:
           type: boolean
+        reason:
+          type: string
+          description: Exact reason when a punch is rejected
         notes:
           type: string
+          description: 'Deprecated: use `reason` instead'
         event_id:
           type: integer
       required:


### PR DESCRIPTION
## Summary
- regenerate OpenAPI spec
- include `reason` field next to deprecated `notes` in punch response schema

## Testing
- `python manage.py spectacular --file tests/swagger/openapi.yaml`
- `pytest tests/swagger/test_schema.py`


------
https://chatgpt.com/codex/tasks/task_e_68c7d3927ef0832dad135b557132b7f8