### PR TITLE
chore: correct libgdk-pixbuf package name

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ WORKDIR /app
 # Install system dependencies
 RUN apt-get update \
  && apt-get install -y build-essential libpq-dev \
-    libcairo2 libpango-1.0-0 libgdk-pixbuf2.0-0 libffi-dev \
+    libcairo2 libpango-1.0-0 libgdk-pixbuf-2.0-0 libffi-dev \
  && rm -rf /var/lib/apt/lists/*
 
 # Install Python dependencies
@@ -27,7 +27,7 @@ ENV PYTHONUNBUFFERED 1
 WORKDIR /app
 RUN apt-get update \
  && apt-get install -y curl dnsutils \
-    libcairo2 libpango-1.0-0 libgdk-pixbuf2.0-0 libffi-dev \
+    libcairo2 libpango-1.0-0 libgdk-pixbuf-2.0-0 libffi-dev \
  && rm -rf /var/lib/apt/lists/*
 
 COPY --from=builder /root/.local /root/.local

--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ Face enrollment and image storage rely on `boto3` and valid AWS credentials.
    ```
 2. Install system libraries required by [WeasyPrint](https://weasyprint.org/):
    ```bash
-   sudo apt-get install libcairo2 libpango-1.0-0 libgdk-pixbuf2.0-0 libffi-dev
+   sudo apt-get install libcairo2 libpango-1.0-0 libgdk-pixbuf-2.0-0 libffi-dev
    ```
 3. Copy `.env.example` to `.env` and adjust database credentials.
 4. Add AWS Rekognition and S3 settings to `.env`:


### PR DESCRIPTION
## Summary
- fix libgdk-pixbuf package name in Dockerfile
- update dependency instructions in README

## Testing
- `flake8 .`
- `DJANGO_SETTINGS_MODULE=config.settings.test pytest -q` *(fails: KeyboardInterrupt after 128 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68c82c9e6860832da66fa00829e8c16c