### PR TITLE
Install additional font dependencies for WeasyPrint runtime

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,9 @@ ENV PYTHONUNBUFFERED 1
 WORKDIR /app
 RUN apt-get update \
  && apt-get install -y curl dnsutils \
-    libcairo2 libpango-1.0-0 libgdk-pixbuf-2.0-0 libffi-dev \
+    libcairo2 libpango-1.0-0 libpangoft2-1.0-0 libpangocairo-1.0-0 \
+    libgdk-pixbuf-2.0-0 libffi-dev libjpeg62-turbo zlib1g fontconfig \
+    fonts-dejavu-core \
  && rm -rf /var/lib/apt/lists/*
 
 COPY --from=builder /root/.local /root/.local


### PR DESCRIPTION
## Summary
- extend the runtime image's system packages to include additional font and image libraries required by WeasyPrint

## Testing
- docker build -t pagasys-local . *(fails: `docker` command not available in execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c8333e1f00832da06cd19e88fa4caf