### PR TITLE
Add admin upload for main employee format

### DIFF
--- a/pagasys/admin.py
+++ b/pagasys/admin.py
@@ -13,7 +13,11 @@ from datetime import timedelta, date
 from copy import deepcopy
 from django.forms.models import construct_instance
 
-from .excel_import import import_employee_workbook, import_company_visa_workbook
+from .excel_import import (
+    import_company_visa_workbook,
+    import_employee_workbook,
+    import_main_format_workbook,
+)
 
 from .utils import scope_queryset
 from .tasks import schedule_range_bulk
@@ -536,6 +540,11 @@ class EmployeeAdmin(CleanSaveModelMixin, ScopedAdminMixin, UserAdmin):
         urls = super().get_urls()
         custom = [
             path(
+                "main-format-upload/",
+                self.admin_site.admin_view(self.main_format_upload),
+                name="pagasys_employee_main_format_upload",
+            ),
+            path(
                 "own-visa-upload/",
                 self.admin_site.admin_view(self.own_visa_upload),
                 name="pagasys_employee_own_visa_upload",
@@ -552,6 +561,30 @@ class EmployeeAdmin(CleanSaveModelMixin, ScopedAdminMixin, UserAdmin):
             ),
         ]
         return custom + urls
+
+    def main_format_upload(self, request):
+        if request.method == "POST":
+            form = self.VisaUploadForm(request.POST, request.FILES)
+            if form.is_valid():
+                results = import_main_format_workbook(form.cleaned_data["file"])
+                if results["created"]:
+                    messages.success(
+                        request, f"Created {results['created']} employees."
+                    )
+                for err in results["errors"]:
+                    messages.error(request, err)
+                return redirect("..")
+        else:
+            form = self.VisaUploadForm()
+        context = dict(
+            self.admin_site.each_context(request),
+            title="Main Format Upload",
+            form=form,
+            opts=self.model._meta,
+        )
+        return TemplateResponse(
+            request, "admin/pagasys/employee/main_format_upload.html", context
+        )
 
     def own_visa_upload(self, request):
         if request.method == "POST":

--- a/pagasys/excel_import.py
+++ b/pagasys/excel_import.py
@@ -4,6 +4,7 @@ from datetime import datetime, date
 from typing import IO, List, Dict, Tuple
 
 from django.contrib.auth.models import Group
+from django.core.exceptions import ValidationError
 from django.db import transaction
 from openpyxl import load_workbook
 
@@ -27,6 +28,120 @@ NATIONALITY_MAP = {
     "GHANA": "GH",
     "NIGERIAN": "NG",
 }
+
+
+def _normalize_header(value: object) -> str:
+    return "".join(ch for ch in str(value or "").upper() if ch.isalnum())
+
+
+MAIN_FORMAT_HEADER_MAP = {
+    "FIRSTNAME": "first_name",
+    "MIDDLENAME": "middle_name",
+    "LASTNAME": "last_name",
+    "BRANCH": "branch",
+    "TRADELICENSE": "trade_license",
+    "TRADERLICENSE": "trade_license",
+    "TRADRLICENSE": "trade_license",
+    "TRADELICENCE": "trade_license",
+    "TRADERLICENCE": "trade_license",
+    "TRADRLICENCE": "trade_license",
+    "TRADLICENSE": "trade_license",
+    "VISATYPE": "visa_type",
+    "PAYMENTSTATUS": "payment_status",
+    "WPSACCOUNTNUMBER": "wps_account_number",
+    "WPSACCNUMBER": "wps_account_number",
+    "WPSACNUMBER": "wps_account_number",
+    "WPSACCNUMEBR": "wps_account_number",
+    "WPSACCOUNTNO": "wps_account_number",
+    "WPSACCNO": "wps_account_number",
+    "DESIGNATION": "designation",
+    "C3NUMBER": "c3_number",
+    "C3NO": "c3_number",
+    "C3ID": "c3_number",
+    "HIREDATE": "hire_date",
+    "DATEOFJOINING": "hire_date",
+    "DOJ": "hire_date",
+    "GENDER": "gender",
+}
+
+
+MAIN_FORMAT_REQUIRED_COLUMNS = {
+    "first_name",
+    "branch",
+    "trade_license",
+    "visa_type",
+    "payment_status",
+    "hire_date",
+}
+
+
+VISA_TYPE_MAP = {
+    "COMPANY": "company",
+    "COMPANYVISA": "company",
+    "PERSONAL": "personal",
+    "PERSONALVISA": "personal",
+    "OWN": "personal",
+    "OWNVISA": "personal",
+    "VISIT": "visit",
+    "VISITVISA": "visit",
+}
+
+
+PAYMENT_STATUS_MAP = {
+    "WPS": "wps",
+    "CASH": "cash",
+}
+
+
+def _stringify(value: object) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, float):
+        if value.is_integer():
+            return str(int(value))
+        return str(value)
+    return str(value)
+
+
+def _is_empty(value: object) -> bool:
+    if value is None:
+        return True
+    if isinstance(value, str) and not value.strip():
+        return True
+    return False
+
+
+def _parse_hire_date(raw: object) -> date:
+    if raw is None:
+        raise ValueError("missing hire date")
+    if isinstance(raw, datetime):
+        return raw.date()
+    if isinstance(raw, date):
+        return raw
+    text = str(raw).strip()
+    if not text:
+        raise ValueError("missing hire date")
+    for fmt in ("%Y/%m/%d", "%Y-%m-%d", "%d/%m/%Y", "%d-%m-%Y"):
+        try:
+            return datetime.strptime(text, fmt).date()
+        except ValueError:
+            continue
+    try:
+        return date.fromisoformat(text)
+    except ValueError:
+        pass
+    raise ValueError(f"could not parse hire date '{text}'")
+
+
+def _normalize_gender(raw: object) -> str:
+    text = _stringify(raw).strip().lower()
+    if not text:
+        return ""
+    if text in {"male", "m"}:
+        return "male"
+    if text in {"female", "f"}:
+        return "female"
+    raise ValueError(f"Unsupported gender '{raw}'")
 
 
 def _split_name(raw: str) -> Tuple[str, str, str]:
@@ -231,4 +346,177 @@ def import_company_visa_workbook(file: IO[bytes]) -> Dict[str, object]:
                     results["created"] += 1
             except Exception as exc:
                 results["errors"].append(f"{sheet_name} row {row_num}: {exc}")
+    return results
+
+
+def import_main_format_workbook(file: IO[bytes]) -> Dict[str, object]:
+    """Import employees using the standardized main Excel format."""
+
+    wb = load_workbook(file, data_only=True)
+    ws = wb.active
+    results: Dict[str, object] = {"created": 0, "errors": []}
+
+    header_row = next(ws.iter_rows(min_row=1, max_row=1, values_only=True), None)
+    if not header_row:
+        results["errors"].append("Workbook is missing a header row")
+        return results
+
+    header_index: Dict[str, int] = {}
+    for idx, raw_header in enumerate(header_row):
+        canonical = MAIN_FORMAT_HEADER_MAP.get(_normalize_header(raw_header))
+        if canonical and canonical not in header_index:
+            header_index[canonical] = idx
+
+    missing_columns = [col for col in MAIN_FORMAT_REQUIRED_COLUMNS if col not in header_index]
+    if missing_columns:
+        results["errors"].append(
+            "Missing required columns: " + ", ".join(sorted(missing_columns))
+        )
+        return results
+
+    group, _ = Group.objects.get_or_create(name=EMPLOYEE_ROLE)
+
+    for row_num, row in enumerate(ws.iter_rows(min_row=2, values_only=True), start=2):
+        if row is None or all(_is_empty(cell) for cell in row):
+            continue
+        try:
+            first_raw = _stringify(row[header_index["first_name"]]).strip()
+            if not first_raw:
+                raise ValueError("missing first name")
+            first = first_raw.title()
+
+            middle = ""
+            if "middle_name" in header_index:
+                middle = _stringify(row[header_index["middle_name"]]).strip().title()
+
+            last = ""
+            if "last_name" in header_index:
+                last = _stringify(row[header_index["last_name"]]).strip().title()
+
+            branch_name = _stringify(row[header_index["branch"]]).strip()
+            if not branch_name:
+                raise ValueError("missing branch name")
+            branch = Branch.objects.filter(name__iexact=branch_name).select_related("company").first()
+            if not branch:
+                raise ValueError(f"Unknown branch '{branch_name}'")
+            department, _ = Department.objects.get_or_create(branch=branch, name="General")
+
+            visa_raw = _stringify(row[header_index["visa_type"]]).strip()
+            if not visa_raw:
+                raise ValueError("missing visa type")
+            visa_type = VISA_TYPE_MAP.get(visa_raw.replace(" ", "").upper())
+            if not visa_type:
+                raise ValueError(f"Unsupported visa type '{visa_raw}'")
+
+            payment_raw = _stringify(row[header_index["payment_status"]]).strip()
+            if not payment_raw:
+                raise ValueError("missing payment status")
+            payment_status = PAYMENT_STATUS_MAP.get(payment_raw.replace(" ", "").upper())
+            if not payment_status:
+                raise ValueError(f"Unsupported payment status '{payment_raw}'")
+            if visa_type != "company" and payment_status != "cash":
+                raise ValueError("Personal or visit visa requires cash payment")
+
+            trade_license_number = ""
+            if "trade_license" in header_index:
+                trade_license_number = _stringify(row[header_index["trade_license"]]).strip()
+
+            trade_license = None
+            if visa_type == "company":
+                if not trade_license_number:
+                    raise ValueError("missing trade license number for company visa")
+                trade_license = TradeLicense.objects.filter(
+                    license_no__iexact=trade_license_number
+                ).select_related("company").first()
+                if not trade_license:
+                    raise ValueError(f"Unknown trade license '{trade_license_number}'")
+                if trade_license.company_id != branch.company_id:
+                    raise ValueError(
+                        f"Trade license '{trade_license_number}' belongs to a different company"
+                    )
+                trade_license.branches.add(branch)
+            else:
+                trade_license = None
+
+            designation = None
+            if "designation" in header_index:
+                designation_name = _stringify(row[header_index["designation"]]).strip()
+                if designation_name:
+                    designation = Designation.objects.filter(
+                        company=branch.company, name__iexact=designation_name
+                    ).first()
+                    if not designation:
+                        designation = Designation.objects.create(
+                            company=branch.company, name=designation_name
+                        )
+
+            wps_account_number = ""
+            if "wps_account_number" in header_index:
+                wps_account_number = _stringify(
+                    row[header_index["wps_account_number"]]
+                ).strip()
+            if payment_status == "wps" and not wps_account_number:
+                raise ValueError("WPS account number is required when payment status is WPS")
+            if payment_status != "wps":
+                wps_account_number = ""
+
+            c3_id = ""
+            if "c3_number" in header_index:
+                c3_id = _stringify(row[header_index["c3_number"]]).strip()
+            if visa_type != "company":
+                c3_id = ""
+
+            hire_date = _parse_hire_date(row[header_index["hire_date"]])
+
+            gender = ""
+            if "gender" in header_index:
+                gender = _normalize_gender(row[header_index["gender"]])
+
+            username_parts = [part for part in [first, middle, last] if part]
+            username_base = "".join(part.lower() for part in username_parts)
+            if not username_base:
+                username_base = f"employee{row_num}"
+            username = username_base
+            suffix = 1
+            while Employee.objects.filter(username=username).exists():
+                username = f"{username_base}{suffix}"
+                suffix += 1
+
+            with transaction.atomic():
+                employee = Employee(
+                    username=username,
+                    first_name=first,
+                    middle_name=middle,
+                    last_name=last,
+                    visa_type=visa_type,
+                    payment_status=payment_status,
+                    wps_account_number=wps_account_number,
+                    department=department,
+                    designation=designation,
+                    trade_license=trade_license,
+                    hire_date=hire_date,
+                    employment_type="permanent",
+                    c3_id=c3_id,
+                    gender=gender,
+                    is_active=True,
+                    is_staff=False,
+                    is_superuser=False,
+                )
+                employee.set_password("carhub123")
+                employee.full_clean()
+                employee.save()
+                employee.groups.set([group])
+                results["created"] += 1
+        except ValidationError as exc:
+            if hasattr(exc, "message_dict"):
+                parts = []
+                for field, messages in exc.message_dict.items():
+                    parts.append(f"{field}: {', '.join(messages)}")
+                message = "; ".join(parts)
+            else:
+                message = "; ".join(exc.messages)
+            results["errors"].append(f"Row {row_num}: {message}")
+        except Exception as exc:
+            results["errors"].append(f"Row {row_num}: {exc}")
+
     return results

--- a/pagasys/templates/admin/pagasys/employee/change_list.html
+++ b/pagasys/templates/admin/pagasys/employee/change_list.html
@@ -1,6 +1,7 @@
 {% extends "admin/change_list.html" %}
 {% block object-tools-items %}
 {{ block.super }}
+<li><a href="{% url 'admin:pagasys_employee_main_format_upload' %}">Main Format Upload</a></li>
 <li><a href="{% url 'admin:pagasys_employee_own_visa_upload' %}">Own visa upload</a></li>
 <li><a href="{% url 'admin:pagasys_employee_company_visa_upload' %}">Company visa upload</a></li>
 <li><a href="{% url 'admin:pagasys_employee_reset_id_sequence' %}">Reset ID Sequence</a></li>

--- a/pagasys/templates/admin/pagasys/employee/main_format_upload.html
+++ b/pagasys/templates/admin/pagasys/employee/main_format_upload.html
@@ -1,0 +1,11 @@
+{% extends "admin/base_site.html" %}
+{% load i18n %}
+{% block content %}
+<h1>Main Format Upload</h1>
+<p>Upload the standard employee Excel file to create multiple employees at once.</p>
+<form method="post" enctype="multipart/form-data">
+  {% csrf_token %}
+  {{ form.as_p }}
+  <input type="submit" value="Upload" class="default" />
+</form>
+{% endblock %}

--- a/pagasys/tests/test_excel_import.py
+++ b/pagasys/tests/test_excel_import.py
@@ -1,0 +1,139 @@
+import io
+import os
+from datetime import date
+
+import django
+import pytest
+from django.core.management import call_command
+from openpyxl import Workbook
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "config.settings.test")
+django.setup()
+call_command("migrate", run_syncdb=True, verbosity=0)
+
+from pagasys.excel_import import import_main_format_workbook
+from pagasys.models import Branch, Company, Department, Designation, Employee, TradeLicense
+from pagasys.policy.permissions import EMPLOYEE_ROLE
+
+
+def _build_workbook(rows):
+    workbook = Workbook()
+    sheet = workbook.active
+    for row in rows:
+        sheet.append(row)
+    stream = io.BytesIO()
+    workbook.save(stream)
+    stream.seek(0)
+    return stream
+
+
+@pytest.fixture(autouse=True)
+def reset_db():
+    call_command("flush", verbosity=0, interactive=False)
+
+
+def test_main_format_import_creates_employee():
+    company = Company.objects.create(name="OMG Group")
+    branch = Branch.objects.create(company=company, name="CAR OMG")
+    trade_license = TradeLicense.objects.create(
+        company=company, license_no="EMP-OMG", max_visas=10
+    )
+
+    header = [
+        "FIRST NAME",
+        "MIDDLE NAME",
+        "LAST NAME",
+        "BRANCH",
+        "TRADR LICENSE",
+        "VISA TYPE",
+        "PAYMENT STATUS",
+        "WPS ACC NUMEBR",
+        "DESIGNATION",
+        "C3 NUMBER",
+        "HIRE DATE",
+        "GENDER",
+    ]
+    data = [
+        "JAMAN",
+        "MIAH",
+        "KHAN",
+        "CAR OMG",
+        "EMP-OMG",
+        "COMPANY",
+        "WPS",
+        "30122109131140",
+        "SENIOR UPHOLSTERY",
+        "COAA 05",
+        "2022/06/10",
+        "MALE",
+    ]
+    stream = _build_workbook([header, data])
+
+    results = import_main_format_workbook(stream)
+
+    assert results["created"] == 1
+    assert results["errors"] == []
+
+    employee = Employee.objects.get()
+    assert employee.first_name == "Jaman"
+    assert employee.middle_name == "Miah"
+    assert employee.last_name == "Khan"
+    assert employee.visa_type == "company"
+    assert employee.payment_status == "wps"
+    assert employee.wps_account_number == "30122109131140"
+    assert employee.trade_license == trade_license
+    assert employee.c3_id == "COAA 05"
+    assert employee.hire_date == date(2022, 6, 10)
+    assert employee.gender == "male"
+    assert employee.employment_type == "permanent"
+    assert employee.groups.filter(name=EMPLOYEE_ROLE).exists()
+
+    department = Department.objects.get(branch=branch, name="General")
+    assert employee.department == department
+    assert trade_license.branches.filter(pk=branch.pk).exists()
+
+    designation = Designation.objects.get(company=company)
+    assert designation.name == "SENIOR UPHOLSTERY"
+    assert employee.designation == designation
+
+
+def test_main_format_import_reports_unknown_branch():
+    company = Company.objects.create(name="OMG Group")
+    TradeLicense.objects.create(company=company, license_no="EMP-OMG", max_visas=5)
+
+    header = [
+        "FIRST NAME",
+        "MIDDLE NAME",
+        "LAST NAME",
+        "BRANCH",
+        "TRADR LICENSE",
+        "VISA TYPE",
+        "PAYMENT STATUS",
+        "WPS ACC NUMEBR",
+        "DESIGNATION",
+        "C3 NUMBER",
+        "HIRE DATE",
+        "GENDER",
+    ]
+    data = [
+        "John",
+        "",
+        "Doe",
+        "Unknown Branch",
+        "EMP-OMG",
+        "COMPANY",
+        "WPS",
+        "123456",
+        "Mechanic",
+        "C3-1",
+        "2022/06/10",
+        "MALE",
+    ]
+    stream = _build_workbook([header, data])
+
+    results = import_main_format_workbook(stream)
+
+    assert results["created"] == 0
+    assert len(results["errors"]) == 1
+    assert "unknown branch" in results["errors"][0].lower()
+    assert Employee.objects.count() == 0

--- a/pagasys/tests/test_excel_import.py
+++ b/pagasys/tests/test_excel_import.py
@@ -1,15 +1,11 @@
 import io
-import os
 from datetime import date
 
-import django
 import pytest
 from django.core.management import call_command
 from openpyxl import Workbook
 
-os.environ.setdefault("DJANGO_SETTINGS_MODULE", "config.settings.test")
-django.setup()
-call_command("migrate", run_syncdb=True, verbosity=0)
+pytestmark = pytest.mark.django_db(transaction=True)
 
 from pagasys.excel_import import import_main_format_workbook
 from pagasys.models import Branch, Company, Department, Designation, Employee, TradeLicense
@@ -28,7 +24,7 @@ def _build_workbook(rows):
 
 
 @pytest.fixture(autouse=True)
-def reset_db():
+def reset_db(transactional_db):
     call_command("flush", verbosity=0, interactive=False)
 
 


### PR DESCRIPTION
## Summary
- implement a robust importer for the main employee Excel format, including header normalization, validation, and automatic designation creation
- expose a new "Main Format Upload" action in the employee admin that uses the importer
- add targeted tests for the importer to cover successful creation and error scenarios

## Testing
- pytest pagasys/tests/test_excel_import.py

------
https://chatgpt.com/codex/tasks/task_e_68c835075278832dbf21060553ec3956