### PR TITLE
Regenerate OpenAPI schema to drop Employee password requirement

### DIFF
--- a/tests/swagger/openapi.yaml
+++ b/tests/swagger/openapi.yaml
@@ -9857,7 +9857,6 @@ components:
       - employment_type
       - hire_date
       - id
-      - password
       - username
     EmployeeSerializerBulkCreateResponse:
       type: object


### PR DESCRIPTION
## Summary
- regenerate the DRF Spectacular schema to reflect current Employee metadata
- update tests/swagger/openapi.yaml so the Employee model no longer requires a password field

## Testing
- pytest tests/swagger/test_schema.py

------
https://chatgpt.com/codex/tasks/task_e_68c8525bb784832db7a35b124c83908b