### PR TITLE
Document employees array in schedule range schema

### DIFF
--- a/pagasys/policy/views.py
+++ b/pagasys/policy/views.py
@@ -321,7 +321,9 @@ class RosterViewSet(BasePolicyViewSet):
             "Create or update consecutive roster entries starting from `start_date`."
             " Provide either `days` (number of days) or `until` (inclusive end date)."
             " `rest_weekdays` may list weekday codes such as ['SAT','SUN'] to mark"
-            " rest days automatically. Entries on calendar holidays are flagged"
+            " rest days automatically. Provide exactly one of `employee`,"
+            " `employees`, or `branch`. Use the `employees` array to schedule"
+            " multiple employees by ID (e.g., [1, 2, 3]). Entries on calendar holidays are flagged"
             " with `is_holiday`, and `was_holiday` records that a holiday was"
             " originally scheduled."
         ),
@@ -337,12 +339,17 @@ class RosterViewSet(BasePolicyViewSet):
                 },
             ),
             OpenApiExample(
-                "Multiple employees",
+                "Employees array",
+                summary="Schedule multiple employees in one request",
+                description=(
+                    "Send employee primary keys in the `employees` array to assign"
+                    " the same shift to each employee."
+                ),
                 value={
-                    "employees": [1, 2],
+                    "employees": [1, 2, 3],
                     "shift": 1,
                     "start_date": "2024-07-01",
-                    "days": 3,
+                    "until": "2024-07-07",
                 },
             ),
             OpenApiExample(

--- a/tests/swagger/openapi.yaml
+++ b/tests/swagger/openapi.yaml
@@ -3217,8 +3217,10 @@ paths:
       description: Create or update consecutive roster entries starting from `start_date`.
         Provide either `days` (number of days) or `until` (inclusive end date). `rest_weekdays`
         may list weekday codes such as ['SAT','SUN'] to mark rest days automatically.
-        Entries on calendar holidays are flagged with `is_holiday`, and `was_holiday`
-        records that a holiday was originally scheduled.
+        Provide exactly one of `employee`, `employees`, or `branch`. Use the `employees`
+        array to schedule multiple employees by ID (e.g., [1, 2, 3]). Entries on calendar
+        holidays are flagged with `is_holiday`, and `was_holiday` records that a holiday
+        was originally scheduled.
       parameters:
       - in: path
         name: company_id
@@ -3244,15 +3246,18 @@ paths:
                   - SAT
                   - SUN
                 summary: By days with weekend rest
-              MultipleEmployees:
+              EmployeesArray:
                 value:
                   employees:
                   - 1
                   - 2
+                  - 3
                   shift: 1
                   start_date: '2024-07-01'
-                  days: 3
-                summary: Multiple employees
+                  until: '2024-07-07'
+                summary: Schedule multiple employees in one request
+                description: Send employee primary keys in the `employees` array to
+                  assign the same shift to each employee.
               UntilDate:
                 value:
                   employee: 1
@@ -3286,15 +3291,18 @@ paths:
                     - SAT
                     - SUN
                   summary: By days with weekend rest
-                MultipleEmployees:
+                EmployeesArray:
                   value:
                     employees:
                     - 1
                     - 2
+                    - 3
                     shift: 1
                     start_date: '2024-07-01'
-                    days: 3
-                  summary: Multiple employees
+                    until: '2024-07-07'
+                  summary: Schedule multiple employees in one request
+                  description: Send employee primary keys in the `employees` array
+                    to assign the same shift to each employee.
                 UntilDate:
                   value:
                     employee: 1


### PR DESCRIPTION
## Summary
- clarify the schedule range endpoint description to highlight the `employees` array usage
- regenerate the OpenAPI document so the Swagger example shows the employees list

## Testing
- python manage.py spectacular --file tests/swagger/openapi.yaml

------
https://chatgpt.com/codex/tasks/task_e_68c866a58f2c832da331cb6b5c57fae8