### PR TITLE
Adjust admin enrollment link expiry to ten days

### DIFF
--- a/pagasys/admin.py
+++ b/pagasys/admin.py
@@ -1,3 +1,6 @@
+import csv
+import io
+
 from django.contrib import admin, messages
 from django.contrib.auth.admin import UserAdmin
 from django.contrib.auth.forms import AdminUserCreationForm, UserChangeForm
@@ -9,9 +12,11 @@ from django.shortcuts import redirect
 from django.template.response import TemplateResponse
 from django.urls import path
 from django.db.models import Max
+from django.http import HttpResponse
 from datetime import timedelta, date
 from copy import deepcopy
 from django.forms.models import construct_instance
+from django.utils import timezone
 
 from .excel_import import (
     import_company_visa_workbook,
@@ -39,6 +44,8 @@ from .models import (
     LeaveType,
     holiday_flags,
 )
+
+from capture.models import EnrollmentLink
 
 ASYNC_BULK_THRESHOLD = 50
 
@@ -420,6 +427,10 @@ class EmployeeAdmin(CleanSaveModelMixin, ScopedAdminMixin, UserAdmin):
     class VisaUploadForm(forms.Form):
         file = forms.FileField()
 
+    list_display = ("id",) + UserAdmin.list_display
+    ordering = ("id",)
+    actions = ["delete_selected", "download_enrollment_links_csv"]
+
     list_filter = UserAdmin.list_filter + (
         "visa_type",
         "employment_type",
@@ -535,6 +546,99 @@ class EmployeeAdmin(CleanSaveModelMixin, ScopedAdminMixin, UserAdmin):
             },
         ),
     )
+
+    @admin.action(description="Download face enrollment links (CSV)")
+    def download_enrollment_links_csv(self, request, queryset):
+        employees = list(
+            queryset.select_related(
+                "trade_license__company",
+                "department__branch__company",
+                "project__branch__company",
+            )
+        )
+        if not employees:
+            self.message_user(
+                request, "No employees selected for CSV export.", level=messages.WARNING
+            )
+            return None
+
+        buffer = io.StringIO()
+        writer = csv.writer(buffer)
+        writer.writerow(
+            [
+                "Employee ID",
+                "Username",
+                "Full name",
+                "Email",
+                "Company",
+                "Enrollment URL",
+                "Token",
+                "Expires at",
+                "Max uses",
+                "Status",
+            ]
+        )
+
+        errors = []
+        for employee in employees:
+            full_name = employee.get_full_name().strip()
+            if not full_name:
+                full_name = employee.username
+            company = employee.company
+            company_name = company.name if company else ""
+            email = employee.email or ""
+            try:
+                expires_at = timezone.now() + timedelta(days=10)
+                link = EnrollmentLink.objects.create(
+                    employee=employee,
+                    expires_at=expires_at,
+                    max_uses=1,
+                )
+            except Exception as exc:  # pragma: no cover - defensive guard
+                status = f"error: {exc}"
+                errors.append(employee)
+                writer.writerow(
+                    [
+                        employee.id,
+                        employee.username,
+                        full_name,
+                        email,
+                        company_name,
+                        "",
+                        "",
+                        "",
+                        "",
+                        status,
+                    ]
+                )
+                continue
+
+            writer.writerow(
+                [
+                    employee.id,
+                    employee.username,
+                    full_name,
+                    email,
+                    company_name,
+                    link.url,
+                    link.token,
+                    link.expires_at.isoformat(),
+                    link.max_uses,
+                    "created",
+                ]
+            )
+
+        if errors:
+            self.message_user(
+                request,
+                f"Failed to create links for {len(errors)} employee(s); see CSV for details.",
+                level=messages.WARNING,
+            )
+
+        response = HttpResponse(buffer.getvalue(), content_type="text/csv")
+        filename = timezone.now().strftime("enrollment-links-%Y%m%d%H%M%S.csv")
+        response["Content-Disposition"] = f"attachment; filename={filename}"
+        return response
 
     def get_urls(self):
         urls = super().get_urls()

--- a/pagasys/tests/test_admin_employee_enrollment_links.py
+++ b/pagasys/tests/test_admin_employee_enrollment_links.py
@@ -1,0 +1,114 @@
+import csv
+import io
+from datetime import timedelta
+from unittest import mock
+
+from django.contrib.admin.sites import AdminSite
+from django.contrib.auth import get_user_model
+from django.test import RequestFactory, TestCase
+from django.utils import timezone
+
+from capture.models import EnrollmentLink
+from pagasys.admin import EmployeeAdmin
+from pagasys.models import Branch, Company, Department, TradeLicense
+
+
+class EmployeeAdminEnrollmentLinkTests(TestCase):
+    def setUp(self):
+        User = get_user_model()
+        self.company = Company.objects.create(name="Acme")
+        self.branch = Branch.objects.create(company=self.company, name="HQ")
+        self.department = Department.objects.create(branch=self.branch, name="IT")
+        self.trade_license = TradeLicense.objects.create(
+            company=self.company,
+            license_no="TL-1",
+            issued_date="2024-01-01",
+            expiry_date="2030-01-01",
+            max_visas=10,
+        )
+        self.trade_license.branches.set([self.branch])
+
+        self.admin_user = User.objects.create_superuser(
+            username="admin",
+            password="pass",
+            trade_license=self.trade_license,
+            department=self.department,
+            hire_date="2024-01-01",
+            employment_type="permanent",
+            visa_type="company",
+        )
+
+        self.employee_1 = User.objects.create_user(
+            username="emp1",
+            password="pass",
+            first_name="Alice",
+            last_name="Example",
+            email="emp1@example.com",
+            trade_license=self.trade_license,
+            department=self.department,
+            hire_date="2024-01-02",
+            employment_type="permanent",
+            visa_type="company",
+        )
+
+        self.employee_2 = User.objects.create_user(
+            username="emp2",
+            password="pass",
+            first_name="Bob",
+            last_name="Sample",
+            trade_license=self.trade_license,
+            department=self.department,
+            hire_date="2024-01-03",
+            employment_type="permanent",
+            visa_type="company",
+        )
+
+        self.site = AdminSite()
+        self.factory = RequestFactory()
+
+    def test_list_display_includes_id(self):
+        admin = EmployeeAdmin(get_user_model(), self.site)
+        self.assertIn("id", admin.list_display)
+        self.assertEqual(admin.list_display[0], "id")
+
+    def test_download_enrollment_links_csv(self):
+        admin = EmployeeAdmin(get_user_model(), self.site)
+        request = self.factory.post("/")
+        request.user = self.admin_user
+
+        queryset = get_user_model().objects.filter(
+            pk__in=[self.employee_1.pk, self.employee_2.pk]
+        )
+        fixed_now = timezone.now()
+
+        with mock.patch("pagasys.admin.timezone.now", return_value=fixed_now):
+            response = admin.download_enrollment_links_csv(request, queryset)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response["Content-Type"], "text/csv")
+        self.assertIn("enrollment-links-", response["Content-Disposition"])
+
+        content = response.content.decode("utf-8")
+        rows = list(csv.DictReader(io.StringIO(content)))
+        self.assertEqual(len(rows), 2)
+
+        returned_ids = {int(row["Employee ID"]) for row in rows}
+        self.assertEqual(returned_ids, {self.employee_1.id, self.employee_2.id})
+
+        expected_expires_at = (fixed_now + timedelta(days=10)).isoformat()
+
+        for row in rows:
+            self.assertEqual(row["Status"], "created")
+            self.assertTrue(row["Enrollment URL"])
+            self.assertTrue(row["Token"])
+            self.assertEqual(row["Expires at"], expected_expires_at)
+            self.assertEqual(row["Max uses"], "1")
+
+        links = EnrollmentLink.objects.filter(
+            employee__in=[self.employee_1, self.employee_2]
+        )
+        self.assertEqual(links.count(), 2)
+        expected_expires_at_dt = fixed_now + timedelta(days=10)
+        for link in links:
+            self.assertEqual(link.expires_at, expected_expires_at_dt)
+            self.assertEqual(link.max_uses, 1)


### PR DESCRIPTION
## Summary
- show employee IDs on the admin employee changelist for easier sorting
- add a CSV download action that creates enrollment links for the selected employees with a ten-day expiry
- cover the new admin behavior with focused tests

## Testing
- python manage.py test pagasys.tests.test_admin_employee_enrollment_links -v 2

------
https://chatgpt.com/codex/tasks/task_e_68c8887ad350832d80de256c517b1d75