### PR TITLE
Improve late comers report form and PDF styling

### DIFF
--- a/attendance/admin.py
+++ b/attendance/admin.py
@@ -147,19 +147,31 @@ class AttDayAdmin(ScopedAdminMixin, admin.ModelAdmin):
     manual_recompute.short_description = "Manual recompute by date range"
 
     class LateComersReportForm(forms.Form):
-        start = forms.DateField()
-        end = forms.DateField()
+        start = forms.DateField(
+            widget=forms.DateInput(attrs={"type": "date"})
+        )
+        end = forms.DateField(
+            widget=forms.DateInput(attrs={"type": "date"})
+        )
         branch = forms.ModelChoiceField(
-            queryset=Branch.objects.none(), required=False
+            queryset=Branch.objects.none(),
+            required=False,
+            empty_label="All branches",
         )
         department = forms.ModelChoiceField(
-            queryset=Department.objects.none(), required=False
+            queryset=Department.objects.none(),
+            required=False,
+            empty_label="All departments",
         )
         project = forms.ModelChoiceField(
-            queryset=Project.objects.none(), required=False
+            queryset=Project.objects.none(),
+            required=False,
+            empty_label="All projects",
         )
         shift = forms.ModelChoiceField(
-            queryset=ShiftTemplate.objects.none(), required=False
+            queryset=ShiftTemplate.objects.none(),
+            required=False,
+            empty_label="All shifts",
         )
 
         def __init__(self, *args, **kwargs):

--- a/attendance/reports.py
+++ b/attendance/reports.py
@@ -6,12 +6,13 @@ from collections import defaultdict
 from datetime import datetime, date
 from typing import Any, Dict, Iterable, List, Tuple
 
+from django.contrib.staticfiles import finders
 from django.db.models import Q
 from django.template.loader import render_to_string
 from django.utils import timezone
 from django.templatetags.static import static
 
-from weasyprint import HTML
+from weasyprint import HTML, CSS
 
 from .models import AttDay, AttPair
 
@@ -134,7 +135,9 @@ def render_late_comers_pdf(
         "logo_url": logo_url,
     }
     html = render_to_string("reports/late_comers.html", context)
-    return HTML(string=html, base_url=base_url).write_pdf()
+    stylesheet_path = finders.find("attendance/css/reports.css")
+    stylesheets = [CSS(filename=stylesheet_path)] if stylesheet_path else None
+    return HTML(string=html, base_url=base_url).write_pdf(stylesheets=stylesheets)
 
 
 __all__ = [

--- a/attendance/static/attendance/css/reports.css
+++ b/attendance/static/attendance/css/reports.css
@@ -1,0 +1,267 @@
+/* Late comers report stylesheet */
+
+@page {
+  size: A4;
+  margin: 30mm 18mm 25mm;
+  @top-center {
+    content: element(report-header);
+  }
+  @bottom-center {
+    content: element(report-footer);
+  }
+}
+
+body.report-body {
+  font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+  font-size: 11pt;
+  line-height: 1.5;
+  color: #1f2933;
+  background: #ffffff;
+  margin: 0;
+}
+
+p {
+  margin: 0 0 3mm;
+}
+
+.report-header,
+.report-footer {
+  width: 100%;
+  background: #ffffff;
+}
+
+.report-header {
+  position: running(report-header);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12mm;
+  padding-bottom: 4mm;
+  border-bottom: 1px solid #d0d7de;
+}
+
+.report-branding {
+  display: flex;
+  align-items: center;
+  gap: 6mm;
+}
+
+.report-branding .logo {
+  max-height: 26mm;
+}
+
+.report-title {
+  margin: 0;
+  font-size: 20pt;
+  font-weight: 600;
+  color: #0f172a;
+}
+
+.report-period {
+  margin: 1mm 0 0;
+  font-size: 11pt;
+  color: #334155;
+}
+
+.report-meta {
+  text-align: right;
+  font-size: 10pt;
+  color: #475569;
+}
+
+.report-meta .label {
+  margin: 0;
+  text-transform: uppercase;
+  font-size: 8pt;
+  letter-spacing: 0.08em;
+  color: #94a3b8;
+}
+
+.report-meta .timestamp {
+  margin: 1mm 0 0;
+  font-variant-numeric: tabular-nums;
+}
+
+.report-footer {
+  position: running(report-footer);
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding-top: 3mm;
+  border-top: 1px solid #d0d7de;
+  font-size: 9pt;
+  color: #475569;
+}
+
+.report-footer p {
+  margin: 0;
+}
+
+.report-footer .page-number::after {
+  content: " " counter(page) " / " counter(pages);
+  font-variant-numeric: tabular-nums;
+}
+
+main.report-content {
+  margin: 0;
+}
+
+main.report-content > section {
+  margin-bottom: 14mm;
+}
+
+.report-overview {
+  margin-top: 8mm;
+}
+
+.report-overview .intro-text {
+  margin: 0 0 4mm;
+  color: #475569;
+}
+
+.section-divider {
+  border: 0;
+  border-top: 1px solid #d0d7de;
+  margin: 10mm 0 8mm;
+}
+
+.section {
+  page-break-inside: avoid;
+}
+
+.section-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 4mm;
+  flex-wrap: wrap;
+}
+
+.section-title {
+  margin: 0 0 3mm;
+  font-size: 16pt;
+  font-weight: 600;
+  color: #0f172a;
+}
+
+.section-total {
+  margin: 0 0 4mm;
+  color: #475569;
+  font-size: 11pt;
+}
+
+.subsection-title {
+  margin: 6mm 0 2mm;
+  font-size: 13pt;
+  font-weight: 600;
+  color: #1f2937;
+}
+
+.shift-title {
+  margin: 4mm 0 2mm;
+  font-size: 12pt;
+  font-weight: 600;
+  color: #1f2937;
+}
+
+.muted {
+  color: #64748b;
+}
+
+.empty-state {
+  margin: 4mm 0 0;
+  color: #64748b;
+  font-style: italic;
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 4mm 0 6mm;
+  font-size: 10pt;
+}
+
+th,
+td {
+  border: 1px solid #d8dee4;
+  padding: 3mm 4mm;
+  vertical-align: top;
+}
+
+th {
+  background: #f1f5f9;
+  color: #0f172a;
+  font-weight: 600;
+  text-align: left;
+}
+
+tbody tr:nth-child(even) {
+  background: #f8fafc;
+}
+
+.summary-table {
+  margin-top: 4mm;
+}
+
+.summary-table.compact th,
+.summary-table.compact td {
+  padding: 2.4mm 4mm;
+}
+
+.summary-table tfoot th {
+  background: #e2e8f0;
+  font-weight: 700;
+}
+
+.numeric {
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+}
+
+.detail-table thead th {
+  white-space: nowrap;
+}
+
+.detail-table td {
+  font-size: 9.5pt;
+}
+
+.branch-section {
+  padding-bottom: 6mm;
+  border-bottom: 1px solid #e2e8f0;
+}
+
+.branch-section:last-of-type {
+  border-bottom: none;
+}
+
+.department-section {
+  margin-top: 4mm;
+}
+
+.project-section {
+  margin-top: 3mm;
+}
+
+.shift-section {
+  margin-top: 2mm;
+}
+
+.section-metadata {
+  margin: 0 0 3mm;
+  color: #475569;
+  font-size: 10pt;
+}
+
+.grand-total {
+  font-size: 18pt;
+  font-weight: 600;
+  color: #0f172a;
+}
+
+.grand-total-value {
+  font-size: 24pt;
+  font-weight: 700;
+  margin: 2mm 0 0;
+  color: #1d4ed8;
+}

--- a/attendance/templates/admin/late_comers_report.html
+++ b/attendance/templates/admin/late_comers_report.html
@@ -13,8 +13,61 @@
 <div id="content-main">
   <h1>{{ title }}</h1>
   <form method="post" class="form-horizontal">{% csrf_token %}
-    <div class="module">
-      {{ form.as_p }}
+    <div class="module aligned">
+      {{ form.non_field_errors }}
+      <fieldset class="form-section">
+        <legend>{% trans "Date range" %}</legend>
+        <div class="form-row">
+          <label for="{{ form.start.id_for_label }}">{{ form.start.label }}</label>
+          <div class="field">
+            {{ form.start.errors }}
+            {{ form.start }}
+          </div>
+        </div>
+        <div class="form-row">
+          <label for="{{ form.end.id_for_label }}">{{ form.end.label }}</label>
+          <div class="field">
+            {{ form.end.errors }}
+            {{ form.end }}
+          </div>
+        </div>
+      </fieldset>
+      <fieldset class="form-section optional-filters">
+        <legend>{% trans "Optional filters" %}</legend>
+        <p class="help">{% trans "Refine the report by selecting any of the filters below. Leave them blank to include all records." %}</p>
+        <div class="form-row">
+          <label for="{{ form.branch.id_for_label }}">{{ form.branch.label }}</label>
+          <div class="field">
+            {{ form.branch.errors }}
+            {{ form.branch }}
+            <p class="help">{% trans "Optional: limit results to a specific branch." %}</p>
+          </div>
+        </div>
+        <div class="form-row">
+          <label for="{{ form.department.id_for_label }}">{{ form.department.label }}</label>
+          <div class="field">
+            {{ form.department.errors }}
+            {{ form.department }}
+            <p class="help">{% trans "Optional: focus on one department." %}</p>
+          </div>
+        </div>
+        <div class="form-row">
+          <label for="{{ form.project.id_for_label }}">{{ form.project.label }}</label>
+          <div class="field">
+            {{ form.project.errors }}
+            {{ form.project }}
+            <p class="help">{% trans "Optional: narrow the report to a single project." %}</p>
+          </div>
+        </div>
+        <div class="form-row">
+          <label for="{{ form.shift.id_for_label }}">{{ form.shift.label }}</label>
+          <div class="field">
+            {{ form.shift.errors }}
+            {{ form.shift }}
+            <p class="help">{% trans "Optional: analyse late arrivals for one shift." %}</p>
+          </div>
+        </div>
+      </fieldset>
     </div>
     <div class="submit-row">
       <input type="submit" value="{% trans 'Generate' %}" class="default">

--- a/attendance/templates/reports/late_comers.html
+++ b/attendance/templates/reports/late_comers.html
@@ -2,69 +2,141 @@
 <!DOCTYPE html>
 <html>
 <head>
-<meta charset="utf-8"/>
-<title>Late Comers Report</title>
-<style>
-body { font-family: sans-serif; font-size: 12px; margin: 20px; }
-header { text-align: center; margin-bottom: 20px; }
-.logo { height: 60px; }
-table { width: 100%; border-collapse: collapse; margin: 10px 0; }
-th, td { border: 1px solid #333; padding: 4px; }
-h2, h3, h4, h5 { margin: 8px 0 4px 0; }
-.section { page-break-inside: avoid; }
-</style>
+  <meta charset="utf-8"/>
+  <title>Late Comers Report</title>
+  <link rel="stylesheet" href="{% static 'attendance/css/reports.css' %}">
 </head>
-<body>
-<header>
-  <img src="{{ logo_url }}" class="logo" alt="Company Logo"/>
-  <h1>Late Comers Report</h1>
-  <p>{{ start_date }} to {{ end_date }}</p>
-  <p>Generated at {{ generated_at }}</p>
-</header>
-{% for branch_name, branch in data.items %}
-<section class="section">
-  <h2>Branch: {{ branch_name }} ({{ branch.total }} min)</h2>
-  {% for dept_name, dept in branch.departments.items %}
-  <section class="section">
-    <h3>Department: {{ dept_name }} ({{ dept.total }} min)</h3>
-    {% for proj_name, proj in dept.projects.items %}
-    <section class="section">
-      <h4>Project: {{ proj_name }} ({{ proj.total }} min)</h4>
-      {% for shift_name, shift in proj.shifts.items %}
-      <section class="section">
-        <h5>Shift: {{ shift_name }} ({{ shift.total }} min)</h5>
-        <table>
-          <thead>
-            <tr>
-              <th>Employee</th>
-              <th>Date</th>
-              <th>Scheduled Start</th>
-              <th>Actual Arrival</th>
-              <th>Late (min)</th>
-            </tr>
-          </thead>
-          <tbody>
-          {% for emp, records in shift.employees.items %}
-            {% for rec in records %}
-            <tr>
-              <td>{{ emp }}</td>
-              <td>{{ rec.date }}</td>
-              <td>{{ rec.scheduled_start }}</td>
-              <td>{{ rec.actual_arrival }}</td>
-              <td>{{ rec.late_min }}</td>
-            </tr>
-            {% endfor %}
+<body class="report-body">
+  <header class="report-header">
+    <div class="report-branding">
+      <img src="{{ logo_url }}" class="logo" alt="Company Logo"/>
+      <div>
+        <h1 class="report-title">Late Comers Report</h1>
+        <p class="report-period">{{ start_date|date:"Y-m-d" }} &ndash; {{ end_date|date:"Y-m-d" }}</p>
+      </div>
+    </div>
+    <div class="report-meta">
+      <p class="label">Generated</p>
+      <p class="timestamp">{{ generated_at|date:"Y-m-d H:i" }}</p>
+    </div>
+  </header>
+  <footer class="report-footer">
+    <p>Late Comers Report</p>
+    <p class="page-number">Page</p>
+  </footer>
+  <main class="report-content">
+    <section class="report-overview section">
+      <h2 class="section-title">Overview</h2>
+      <p class="intro-text">Summary of recorded late arrivals for the selected period.</p>
+      <table class="summary-table">
+        <thead>
+          <tr>
+            <th>Branch</th>
+            <th class="numeric">Late minutes</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for branch_name, branch in data.items %}
+          <tr>
+            <td>{{ branch_name }}</td>
+            <td class="numeric">{{ branch.total }}</td>
+          </tr>
+          {% empty %}
+          <tr>
+            <td colspan="2" class="empty-state">No late arrivals were recorded for the selected period.</td>
+          </tr>
           {% endfor %}
-          </tbody>
-        </table>
+        </tbody>
+        <tfoot>
+          <tr>
+            <th>Total late minutes</th>
+            <th class="numeric">{{ total_late_min }}</th>
+          </tr>
+        </tfoot>
+      </table>
+    </section>
+
+    {% if data %}
+    <hr class="section-divider"/>
+    {% for branch_name, branch in data.items %}
+    <section class="branch-section section">
+      <div class="section-header">
+        <h2 class="section-title">Branch: {{ branch_name }}</h2>
+        <p class="section-total">Total late minutes: <span class="muted">{{ branch.total }} min</span></p>
+      </div>
+      {% if branch.departments %}
+      <table class="summary-table compact">
+        <thead>
+          <tr>
+            <th>Department</th>
+            <th class="numeric">Late minutes</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for dept_name, dept in branch.departments.items %}
+          <tr>
+            <td>{{ dept_name }}</td>
+            <td class="numeric">{{ dept.total }}</td>
+          </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+      {% endif %}
+      {% for dept_name, dept in branch.departments.items %}
+      <section class="department-section">
+        <h3 class="subsection-title">Department: {{ dept_name }} <span class="muted">({{ dept.total }} min)</span></h3>
+        {% for proj_name, proj in dept.projects.items %}
+        <section class="project-section">
+          <h4 class="subsection-title">Project: {{ proj_name }} <span class="muted">({{ proj.total }} min)</span></h4>
+          {% for shift_name, shift in proj.shifts.items %}
+          <section class="shift-section">
+            <h5 class="shift-title">Shift: {{ shift_name }} <span class="muted">({{ shift.total }} min)</span></h5>
+            <table class="detail-table">
+              <thead>
+                <tr>
+                  <th>Employee</th>
+                  <th>Date</th>
+                  <th>Scheduled Start</th>
+                  <th>Actual Arrival</th>
+                  <th class="numeric">Late (min)</th>
+                </tr>
+              </thead>
+              <tbody>
+                {% for emp, records in shift.employees.items %}
+                  {% for rec in records %}
+                  <tr>
+                    <td>{{ emp }}</td>
+                    <td>{{ rec.date|date:"Y-m-d" }}</td>
+                    <td>{{ rec.scheduled_start|date:"H:i"|default:"-" }}</td>
+                    <td>{{ rec.actual_arrival|date:"H:i"|default:"-" }}</td>
+                    <td class="numeric">{{ rec.late_min }}</td>
+                  </tr>
+                  {% endfor %}
+                {% endfor %}
+              </tbody>
+            </table>
+          </section>
+          {% empty %}
+          <p class="empty-state">No shift data available for this project.</p>
+          {% endfor %}
+        </section>
+        {% empty %}
+        <p class="empty-state">No project data available for this department.</p>
+        {% endfor %}
       </section>
+      {% empty %}
+      <p class="empty-state">No departmental data recorded for this branch.</p>
       {% endfor %}
     </section>
+    {% if not forloop.last %}<hr class="section-divider"/>{% endif %}
     {% endfor %}
-  </section>
-  {% endfor %}
-</section>
-{% endfor %}
-<p><strong>Total late minutes: {{ total_late_min }}</strong></p>
+    {% endif %}
+
+    <section class="grand-total section">
+      <h2 class="section-title">Grand total</h2>
+      <p class="section-total">Combined late minutes for the period</p>
+      <p class="grand-total-value">{{ total_late_min }}</p>
+    </section>
+  </main>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- render the admin late comers report form with explicit fieldsets, helper text, and improved date widgets
- redesign the late comers PDF template to reference a new shared stylesheet with page headers, footers, and summary tables
- update the PDF renderer to load the external stylesheet so WeasyPrint applies the refreshed layout

## Testing
- `python manage.py test attendance.tests.test_reports --verbosity 2`


------
https://chatgpt.com/codex/tasks/task_e_68c90b9655bc832d99e4632dabe6f626