### PR TITLE
Adjust late comers report footer layout

### DIFF
--- a/attendance/static/attendance/css/reports.css
+++ b/attendance/static/attendance/css/reports.css
@@ -84,21 +84,35 @@ p {
 
 .report-footer {
   position: running(report-footer);
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
+  display: table;
+  width: 100%;
+  table-layout: fixed;
   padding-top: 3mm;
   border-top: 1px solid #d0d7de;
   font-size: 9pt;
   color: #475569;
 }
 
-.report-footer p {
-  margin: 0;
+.report-footer > div {
+  display: table-cell;
+  vertical-align: middle;
+}
+
+.report-footer .footer-title {
+  text-align: left;
+}
+
+.report-footer .footer-pagination {
+  text-align: right;
+}
+
+.report-footer .page-number {
+  display: inline-block;
+  white-space: nowrap;
 }
 
 .report-footer .page-number::after {
-  content: " " counter(page) " / " counter(pages);
+  content: "Page " counter(page) " / " counter(pages);
   font-variant-numeric: tabular-nums;
 }
 

--- a/attendance/templates/reports/late_comers.html
+++ b/attendance/templates/reports/late_comers.html
@@ -21,8 +21,10 @@
     </div>
   </header>
   <footer class="report-footer">
-    <p>Late Comers Report</p>
-    <p class="page-number">Page</p>
+    <div class="footer-title">Late Comers Report</div>
+    <div class="footer-pagination">
+      <span class="page-number"></span>
+    </div>
   </footer>
   <main class="report-content">
     <section class="report-overview section">


### PR DESCRIPTION
## Summary
- replace the footer paragraphs with dedicated title and pagination containers in the late comers report template
- rework the footer styling to use a table layout compatible with WeasyPrint and render "Page X / Y"

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68c91a0fb0bc832d8dcd5088cf8eb804