### PR TITLE
Force page breaks between branch sections in reports

### DIFF
--- a/attendance/static/attendance/css/reports.css
+++ b/attendance/static/attendance/css/reports.css
@@ -245,6 +245,11 @@ tbody tr:nth-child(even) {
   border-bottom: 1px solid #e2e8f0;
 }
 
+.branch-section + .branch-section {
+  break-before: page;
+  page-break-before: always;
+}
+
 .branch-section:last-of-type {
   border-bottom: none;
 }


### PR DESCRIPTION
## Summary
- force each branch section after the first to start on a new page to improve pagination
- retain existing running header and footer definitions so they appear on every page

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68c91f05a99c832d8abe278d365334ab