### PR TITLE
Simplify late comers report

### DIFF
--- a/attendance/admin.py
+++ b/attendance/admin.py
@@ -220,8 +220,8 @@ class AttDayAdmin(ScopedAdminMixin, admin.ModelAdmin):
                     if obj is not None:
                         filters[f"{key}_id"] = obj.pk
                 records = get_late_comers(start, end, filters)
-                grouped, stats = group_late_comers(records)
-                pdf = render_late_comers_pdf(grouped, stats, start, end, request)
+                records, stats = group_late_comers(records)
+                pdf = render_late_comers_pdf(records, stats, start, end, request)
                 response = HttpResponse(pdf, content_type="application/pdf")
                 response["Content-Disposition"] = (
                     f"attachment; filename=late_comers_{start}_{end}.pdf"

--- a/attendance/reports.py
+++ b/attendance/reports.py
@@ -2,8 +2,7 @@
 
 from __future__ import annotations
 
-from collections import defaultdict
-from datetime import datetime, date
+from datetime import date
 from typing import Any, Dict, Iterable, List, Tuple
 
 from django.contrib.staticfiles import finders
@@ -14,7 +13,7 @@ from django.templatetags.static import static
 
 from weasyprint import HTML, CSS
 
-from .models import AttDay, AttPair
+from .models import AttDay
 
 
 def get_late_comers(
@@ -23,12 +22,16 @@ def get_late_comers(
     """Return raw late comer records within the given date range."""
 
     filters = filters or {}
-    qs = AttDay.objects.select_related(
-        "employee",
-        "employee__department__branch",
-        "employee__project__branch",
-        "shift",
-    ).filter(date__range=(start_date, end_date), late_min__gt=0)
+    qs = (
+        AttDay.objects.select_related(
+            "employee",
+            "employee__department__branch",
+            "employee__project__branch",
+            "shift",
+        )
+        .filter(date__range=(start_date, end_date), late_min__gt=0)
+        .order_by("employee__first_name", "employee__last_name", "date")
+    )
 
     branch_id = filters.get("branch_id")
     if branch_id:
@@ -48,71 +51,30 @@ def get_late_comers(
 
     records: List[Dict[str, Any]] = []
     for day in qs:
-        pair = (
-            AttPair.objects.filter(employee=day.employee, date=day.date)
-            .order_by("in_ts")
-            .first()
-        )
-        actual = timezone.localtime(pair.in_ts) if pair else None
-        sched = (
-            timezone.make_aware(
-                datetime.combine(day.date, day.shift.start_time)
-            )
-            if day.shift and day.shift.start_time
-            else None
-        )
         records.append(
             {
-                "branch": getattr(day.employee.branch, "name", ""),
-                "department": getattr(day.employee.department, "name", ""),
-                "project": getattr(day.employee.project, "name", ""),
-                "shift": getattr(day.shift, "name", ""),
                 "employee": str(day.employee),
+                "shift": getattr(day.shift, "name", ""),
                 "date": day.date,
-                "scheduled_start": sched,
-                "actual_arrival": actual,
                 "late_min": day.late_min,
             }
         )
     return records
 
 
-def group_late_comers(records: Iterable[Dict[str, Any]]) -> Tuple[Dict[str, Any], Dict[str, Any]]:
-    """Group late comer records by branch/department/project/shift."""
+def group_late_comers(
+    records: Iterable[Dict[str, Any]]
+) -> Tuple[List[Dict[str, Any]], Dict[str, Any]]:
+    """Sort records and compute aggregate late minutes."""
 
-    grouped: Dict[str, Any] = {}
-    grand_total = 0
-    for r in records:
-        branch = r["branch"] or "(Unassigned)"
-        dept = r["department"] or "(Unassigned)"
-        proj = r["project"] or "(Unassigned)"
-        shift = r["shift"] or "(Unassigned)"
-        late = r["late_min"]
-        grand_total += late
-
-        bnode = grouped.setdefault(branch, {"total": 0, "departments": {}})
-        bnode["total"] += late
-        dnode = bnode["departments"].setdefault(dept, {"total": 0, "projects": {}})
-        dnode["total"] += late
-        pnode = dnode["projects"].setdefault(proj, {"total": 0, "shifts": {}})
-        pnode["total"] += late
-        snode = pnode["shifts"].setdefault(shift, {"total": 0, "employees": defaultdict(list)})
-        snode["total"] += late
-
-        snode["employees"][r["employee"]].append(
-            {
-                "date": r["date"],
-                "scheduled_start": r["scheduled_start"],
-                "actual_arrival": r["actual_arrival"],
-                "late_min": late,
-            }
-        )
-
-    return grouped, {"total_late_min": grand_total}
+    records = list(records)
+    records.sort(key=lambda r: (r["employee"], r["date"]))
+    total = sum(r["late_min"] for r in records)
+    return records, {"total_late_min": total}
 
 
 def render_late_comers_pdf(
-    grouped: Dict[str, Any],
+    records: List[Dict[str, Any]],
     stats: Dict[str, Any],
     start_date: date,
     end_date: date,
@@ -127,7 +89,7 @@ def render_late_comers_pdf(
         base_url = request.build_absolute_uri("/")
 
     context = {
-        "data": grouped,
+        "data": records,
         "start_date": start_date,
         "end_date": end_date,
         "generated_at": timezone.now(),

--- a/attendance/templates/reports/late_comers.html
+++ b/attendance/templates/reports/late_comers.html
@@ -27,122 +27,36 @@
     </div>
   </footer>
   <main class="report-content">
-    <section class="report-overview section">
-      <h2 class="section-title">Overview</h2>
-      <p class="intro-text">Summary of recorded late arrivals for the selected period.</p>
-      <table class="summary-table">
-        <thead>
-          <tr>
-            <th>Branch</th>
-            <th class="numeric">Late minutes</th>
-          </tr>
-        </thead>
-        <tbody>
-          {% for branch_name, branch in data.items %}
-          <tr>
-            <td>{{ branch_name }}</td>
-            <td class="numeric">{{ branch.total }}</td>
-          </tr>
-          {% empty %}
-          <tr>
-            <td colspan="2" class="empty-state">No late arrivals were recorded for the selected period.</td>
-          </tr>
-          {% endfor %}
-        </tbody>
-        <tfoot>
-          <tr>
-            <th>Total late minutes</th>
-            <th class="numeric">{{ total_late_min }}</th>
-          </tr>
-        </tfoot>
-      </table>
-    </section>
-
-    {% if data %}
-    <hr class="section-divider"/>
-    {% for branch_name, branch in data.items %}
-    <section class="branch-section section">
-      <div class="section-header">
-        <h2 class="section-title">Branch: {{ branch_name }}</h2>
-        <p class="section-total">Total late minutes: <span class="muted">{{ branch.total }} min</span></p>
-      </div>
-      {% if branch.departments %}
-      <table class="summary-table compact">
-        <thead>
-          <tr>
-            <th>Department</th>
-            <th class="numeric">Late minutes</th>
-          </tr>
-        </thead>
-        <tbody>
-          {% for dept_name, dept in branch.departments.items %}
-          <tr>
-            <td>{{ dept_name }}</td>
-            <td class="numeric">{{ dept.total }}</td>
-          </tr>
-          {% endfor %}
-        </tbody>
-      </table>
-      {% endif %}
-      {% for dept_name, dept in branch.departments.items %}
-      <section class="department-section">
-        <h3 class="subsection-title">Department: {{ dept_name }} <span class="muted">({{ dept.total }} min)</span></h3>
-        {% for proj_name, proj in dept.projects.items %}
-        <section class="project-section">
-          <h4 class="subsection-title">Project: {{ proj_name }} <span class="muted">({{ proj.total }} min)</span></h4>
-          {% for shift_name, shift in proj.shifts.items %}
-          <section class="shift-section">
-            <h5 class="shift-title">Shift: {{ shift_name }} <span class="muted">({{ shift.total }} min)</span></h5>
-            {% if shift.employees %}
-            <table class="detail-table">
-              <thead>
-                <tr>
-                  <th>Employee</th>
-                  <th>Date</th>
-                  <th>Scheduled Start</th>
-                  <th>Actual Arrival</th>
-                  <th class="numeric">Late (min)</th>
-                </tr>
-              </thead>
-              <tbody>
-                {% for emp, records in shift.employees.items %}
-                  {% for rec in records %}
-                  <tr>
-                    <td>{{ emp }}</td>
-                    <td>{{ rec.date|date:"Y-m-d" }}</td>
-                    <td>{{ rec.scheduled_start|date:"H:i"|default:"-" }}</td>
-                    <td>{{ rec.actual_arrival|date:"H:i"|default:"-" }}</td>
-                    <td class="numeric">{{ rec.late_min }}</td>
-                  </tr>
-                  {% endfor %}
-                {% endfor %}
-              </tbody>
-            </table>
-            {% else %}
-            <p class="empty-state">No late arrivals for this shift.</p>
-            {% endif %}
-          </section>
-          {% empty %}
-          <p class="empty-state">No shift data available for this project.</p>
-          {% endfor %}
-        </section>
+    <table class="detail-table">
+      <thead>
+        <tr>
+          <th>Employee</th>
+          <th>Shift</th>
+          <th>Date</th>
+          <th class="numeric">Late (min)</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for rec in data %}
+        <tr>
+          <td>{{ rec.employee }}</td>
+          <td>{{ rec.shift|default:"-" }}</td>
+          <td>{{ rec.date|date:"Y-m-d" }}</td>
+          <td class="numeric">{{ rec.late_min }}</td>
+        </tr>
         {% empty %}
-        <p class="empty-state">No project data available for this department.</p>
+        <tr>
+          <td colspan="4" class="empty-state">No late arrivals were recorded for the selected period.</td>
+        </tr>
         {% endfor %}
-      </section>
-      {% empty %}
-      <p class="empty-state">No departmental data recorded for this branch.</p>
-      {% endfor %}
-    </section>
-    {% if not forloop.last %}<hr class="section-divider"/>{% endif %}
-    {% endfor %}
-    {% endif %}
-
-    <section class="grand-total section">
-      <h2 class="section-title">Grand total</h2>
-      <p class="section-total">Combined late minutes for the period</p>
-      <p class="grand-total-value">{{ total_late_min }}</p>
-    </section>
+      </tbody>
+      <tfoot>
+        <tr>
+          <th colspan="3">Total late minutes</th>
+          <th class="numeric">{{ total_late_min }}</th>
+        </tr>
+      </tfoot>
+    </table>
   </main>
 </body>
 </html>

--- a/attendance/tests/test_reports.py
+++ b/attendance/tests/test_reports.py
@@ -78,10 +78,9 @@ class LateComersReportTests(TestCase):
         filtered = get_late_comers(self.day, self.day, {"branch_id": self.branch1.id})
         assert len(filtered) == 1
         assert filtered[0]["employee"] == str(self.emp1)
-        grouped, stats = group_late_comers(records)
+        ordered, stats = group_late_comers(records)
         assert stats["total_late_min"] == 20
-        assert grouped["B1"]["total"] == 15
-        assert grouped["B2"]["total"] == 5
+        assert {r["employee"] for r in ordered} == {str(self.emp1), str(self.emp2)}
 
     def test_api_late_comers_report(self):
         self.api_client.force_authenticate(self.admin)

--- a/attendance/views.py
+++ b/attendance/views.py
@@ -268,8 +268,8 @@ class AttDayViewSet(viewsets.ReadOnlyModelViewSet):
             if val:
                 filters[f"{key}_id"] = int(val)
         records = get_late_comers(start, end, filters)
-        grouped, stats = group_late_comers(records)
-        pdf = render_late_comers_pdf(grouped, stats, start, end, request)
+        records, stats = group_late_comers(records)
+        pdf = render_late_comers_pdf(records, stats, start, end, request)
         filename = f"late_comers_{start}_{end}.pdf"
         response = HttpResponse(pdf, content_type="application/pdf")
         response["Content-Disposition"] = f"attachment; filename={filename}"


### PR DESCRIPTION
## Summary
- streamline late comers report to list employee, shift, date, and late minutes
- adjust views and admin to use simplified report format
- update report template and tests accordingly

## Testing
- `pytest` *(fails: Requested setting REST_FRAMEWORK, but settings are not configured)*

------
https://chatgpt.com/codex/tasks/task_e_68c95141ddfc832d8195f4e71d34cfd1