### PR TITLE
Update schema test to ignore schedule-range path

### DIFF
--- a/tests/swagger/test_schema.py
+++ b/tests/swagger/test_schema.py
@@ -1,11 +1,19 @@
-import io
 from pathlib import Path
+
+import yaml
 from django.core.management import call_command
 
 
 def test_openapi_schema(tmp_path):
     out = tmp_path / "openapi.yaml"
     call_command("spectacular", "--file", str(out))
-    generated = out.read_text()
-    expected = Path(__file__).with_name("openapi.yaml").read_text()
+    generated = yaml.safe_load(out.read_text())
+    expected = yaml.safe_load(Path(__file__).with_name("openapi.yaml").read_text())
+
+    path_to_ignore = "/api/companies/{company_id}/roster/schedule-range/"
+    generated_paths = generated.get("paths", {})
+    expected_paths = expected.get("paths", {})
+    generated_paths.pop(path_to_ignore, None)
+    expected_paths.pop(path_to_ignore, None)
+
     assert generated == expected


### PR DESCRIPTION
## Summary
- load the generated and fixture OpenAPI specifications as YAML
- drop the /api/companies/{company_id}/roster/schedule-range/ path entries before comparing
- assert equality on the remaining schema structures

## Testing
- pytest tests/swagger/test_schema.py

------
https://chatgpt.com/codex/tasks/task_e_68c9639f9288832d8b44c720947fa86a