### PR TITLE
Simplify late comers report template

### DIFF
--- a/attendance/templates/reports/late_comers.html
+++ b/attendance/templates/reports/late_comers.html
@@ -1,79 +1,53 @@
-{% load static %}
 <!DOCTYPE html>
 <html>
 <head>
-  <meta charset="utf-8"/>
+  <meta charset="utf-8" />
   <title>Late Comers Report</title>
-  <link rel="stylesheet" href="{% static 'attendance/css/reports.css' %}">
 </head>
-<body class="report-body">
-  <header class="report-header">
-    <div class="report-header-primary">
-      <h1 class="report-title">Late Comers Report</h1>
-      <p class="report-period">{{ start_date|date:"d M Y" }} &ndash; {{ end_date|date:"d M Y" }}</p>
-    </div>
-    <div class="report-meta">
-      <p class="label">Generated</p>
-      <p class="timestamp">{{ generated_at|date:"d M Y H:i" }}</p>
-    </div>
-  </header>
-  <footer class="report-footer">
-    <div class="footer-content">
-      <span class="footer-report-title">Late Comers Report</span>
-      <span class="footer-pagination">
-        <span class="page-number"></span>
-      </span>
-    </div>
-  </footer>
-  <main class="report-content">
-    {% if branches %}
-      {% for branch_name, branch in branches.items %}
-      <section class="section branch-section">
-        <div class="section-header">
-          <h2 class="section-title">{{ branch_name }}</h2>
-          <p class="section-total">Total late minutes: {{ branch.total_late_min }}</p>
-        </div>
-        <table class="detail-table">
-          <colgroup>
-            <col class="column-employee">
-            <col class="column-shift">
-            <col class="column-date">
-            <col class="column-late">
-          </colgroup>
-          <thead>
+<body>
+  <h1>Late Comers Report</h1>
+  <p>
+    Date:
+    {% if start_date == end_date %}
+      {{ start_date|date:"d M Y" }}
+    {% else %}
+      {{ start_date|date:"d M Y" }} &ndash; {{ end_date|date:"d M Y" }}
+    {% endif %}
+  </p>
+  <table border="1" cellspacing="0" cellpadding="4">
+    <thead>
+      <tr>
+        <th>Branch</th>
+        <th>Employee</th>
+        <th>Shift</th>
+        <th>Date</th>
+        <th>Late (min)</th>
+      </tr>
+    </thead>
+    <tbody>
+      {% if branches %}
+        {% for branch_name, branch in branches.items %}
+          {% for rec in branch.records %}
             <tr>
-              <th>Employee</th>
-              <th>Shift</th>
-              <th>Date</th>
-              <th class="numeric">Late (min)</th>
-            </tr>
-          </thead>
-          <tbody>
-            {% for rec in branch.records %}
-            <tr>
+              <td>{{ branch_name }}</td>
               <td>{{ rec.employee }}</td>
               <td>{{ rec.shift|default:"-" }}</td>
               <td>{{ rec.date|date:"d M Y" }}</td>
-              <td class="numeric">{{ rec.late_min }}</td>
+              <td>{{ rec.late_min }}</td>
             </tr>
-            {% empty %}
+          {% empty %}
             <tr>
-              <td colspan="4" class="empty-state">No late arrivals were recorded for this branch.</td>
+              <td>{{ branch_name }}</td>
+              <td colspan="4">No late arrivals were recorded for this branch.</td>
             </tr>
-            {% endfor %}
-          </tbody>
-        </table>
-      </section>
-      {% endfor %}
-      <section class="section report-summary">
-        <div class="section-header">
-          <h2 class="section-title grand-total">Grand total late minutes</h2>
-          <p class="section-total grand-total-value">{{ total_late_min }}</p>
-        </div>
-      </section>
-    {% else %}
-      <p class="empty-state">No late arrivals were recorded for the selected period.</p>
-    {% endif %}
-  </main>
+          {% endfor %}
+        {% endfor %}
+      {% else %}
+        <tr>
+          <td colspan="5">No late arrivals were recorded for the selected period.</td>
+        </tr>
+      {% endif %}
+    </tbody>
+  </table>
 </body>
 </html>

--- a/attendance/templates/reports/late_comers.html
+++ b/attendance/templates/reports/late_comers.html
@@ -11,10 +11,10 @@
     {% if start_date == end_date %}
       {{ start_date|date:"d M Y" }}
     {% else %}
-      {{ start_date|date:"d M Y" }} &ndash; {{ end_date|date:"d M Y" }}
+      {{ start_date|date:"d M Y" }} - {{ end_date|date:"d M Y" }}
     {% endif %}
   </p>
-  <table border="1" cellspacing="0" cellpadding="4">
+  <table>
     <thead>
       <tr>
         <th>Branch</th>
@@ -27,20 +27,22 @@
     <tbody>
       {% if branches %}
         {% for branch_name, branch in branches.items %}
-          {% for rec in branch.records %}
-            <tr>
-              <td>{{ branch_name }}</td>
-              <td>{{ rec.employee }}</td>
-              <td>{{ rec.shift|default:"-" }}</td>
-              <td>{{ rec.date|date:"d M Y" }}</td>
-              <td>{{ rec.late_min }}</td>
-            </tr>
-          {% empty %}
+          {% if branch.records %}
+            {% for rec in branch.records %}
+              <tr>
+                <td>{{ branch_name }}</td>
+                <td>{{ rec.employee }}</td>
+                <td>{{ rec.shift|default:"-" }}</td>
+                <td>{{ rec.date|date:"d M Y" }}</td>
+                <td>{{ rec.late_min }}</td>
+              </tr>
+            {% endfor %}
+          {% else %}
             <tr>
               <td>{{ branch_name }}</td>
               <td colspan="4">No late arrivals were recorded for this branch.</td>
             </tr>
-          {% endfor %}
+          {% endif %}
         {% endfor %}
       {% else %}
         <tr>

--- a/attendance/tests/test_reports.py
+++ b/attendance/tests/test_reports.py
@@ -97,7 +97,7 @@ class LateComersReportTests(TestCase):
         assert [r["employee"] for r in branch1_records] == [expected_emp1_name]
         assert [r["employee"] for r in branch2_records] == [expected_emp2_name]
 
-    def test_late_comers_template_uses_new_header_format(self):
+    def test_late_comers_template_renders_simple_layout(self):
         generated_at = timezone.make_aware(datetime(2024, 1, 2, 9, 30))
         branches = OrderedDict(
             (
@@ -141,17 +141,24 @@ class LateComersReportTests(TestCase):
                 "total_late_min": 20,
             },
         )
-        assert 'class="report-header-primary"' in html
-        assert "01 Jan 2024 &ndash; 01 Jan 2024" in html
-        assert "02 Jan 2024 09:30" in html
-        assert 'class="footer-report-title"' in html
-        assert 'class="footer-pagination"' in html
-        assert 'class="column-employee"' in html
+        # The simplified template should just show a heading, the selected date, and a basic table.
+        assert "<h1>Late Comers Report</h1>" in html
+        assert "Date:" in html
+        # When the start and end dates match, only a single date should be shown.
+        assert "01 Jan 2024" in html
+        assert " - " not in html
+        assert "<table>" in html
+        assert "<th>Branch</th>" in html
+        assert "<th>Employee</th>" in html
+        assert "<th>Shift</th>" in html
+        assert "<th>Date</th>" in html
+        assert "<th>Late (min)</th>" in html
         assert f">{self.branch1.name}<" in html
         assert f">{self.branch2.name}<" in html
-        assert "Total late minutes: 15" in html
-        assert "Grand total late minutes" in html
-        assert "20" in html
+        assert "Alice Anderson" in html
+        assert "Bob Brown" in html
+        assert "S1" in html and "S2" in html
+        assert "15" in html and "5" in html
 
     def test_api_late_comers_report(self):
         self.api_client.force_authenticate(self.admin)


### PR DESCRIPTION
## Summary
- replace the late comers PDF template with a minimal layout that only renders a heading, the selected date range, and a simple table of records

## Testing
- pytest attendance/tests/test_reports.py *(fails: django.core.exceptions.ImproperlyConfigured: Requested setting REST_FRAMEWORK, but settings are not configured)*

------
https://chatgpt.com/codex/tasks/task_e_68c97aa5e610832d9e446b04eb2bc321