### PR TITLE
Add reports section to admin dashboard

### DIFF
--- a/pagasys/apps.py
+++ b/pagasys/apps.py
@@ -11,6 +11,7 @@ class PagasysConfig(AppConfig):
         admin.site.site_header = "Pagasys Payroll administration"
         admin.site.site_title = "Pagasys Payroll admin"
         admin.site.index_title = "Pagasys Payroll administration"
+        admin.site.index_template = "admin/pagasys_index.html"
 
         # Django 5.2 expanded the CSRF token character set to include uppercase
         # letters.  Our test suite asserts that certain uppercase strings do

--- a/pagasys/templates/admin/pagasys_index.html
+++ b/pagasys/templates/admin/pagasys_index.html
@@ -1,0 +1,101 @@
+{% extends "admin/base_site.html" %}
+{% load i18n grp_tags log %}
+
+{% block javascripts %}
+    {{ block.super }}
+{% endblock %}
+
+{% block bodyclass %}dashboard{% endblock %}
+{% block content-class %}content-grid{% endblock %}
+
+{% block breadcrumbs %}
+    <ul class="grp-horizontal-list">
+        <li>{% trans "Home" %}</li>
+    </ul>
+{% endblock %}
+
+{% block content_title %}
+    {% if title %}
+        <header><h1>{{ title }}</h1></header>
+    {% endif %}
+{% endblock %}
+
+{% block content %}
+    <div class="g-d-c">
+        <div class="g-d-12 g-d-f">
+            {% for app in app_list %}
+                <div class="grp-module" id="app_{{ app.name|lower }}">
+                    <h2><a href="{{ app.app_url }}" class="grp-section">{% trans app.name %}</a></h2>
+                    {% for model in app.models %}
+                        <div class="grp-row" id="model-{{ model.object_name|lower }}">
+                            {% if model.admin_url %}
+                                <a href="{{ model.admin_url }}"><strong>{{ model.name }}</strong></a>
+                            {% else %}
+                                <strong>{{ model.name }}</strong>
+                            {% endif %}
+                            {% if model.add_url %}
+                                <ul class="grp-actions">
+                                    <li class="grp-icon grp-add-link">
+                                        <a href="{{ model.add_url }}" title="{% trans "Add" %}">&nbsp;</a>
+                                    </li>
+                                </ul>
+                            {% endif %}
+                        </div>
+                    {% endfor %}
+                </div>
+            {% empty %}
+                <p>{% trans "You don´t have permission to edit anything." %}</p>
+            {% endfor %}
+            {% block custom_views %}
+                {% if custom_list %}
+                    <div class="grp-module" id="custom_views">
+                        <h2>{% trans 'Custom Views' %}</h2>
+                        {% for path, name in custom_list %}
+                            <div class="grp-row">
+                                <a href="{{ path }}"><strong>{{ name }}</strong></a>
+                            </div>
+                        {% endfor %}
+                    </div>
+                {% endif %}
+            {% endblock %}
+            {% block pagasys_reports %}
+                {% if perms.attendance.view_attday %}
+                    <div class="grp-module" id="pagasys-reports">
+                        <h2>{% trans "Reports" %}</h2>
+                        <div class="grp-row">
+                            <a href="{% url 'admin:attendance_attday_late_comers_report' %}"><strong>{% trans "Late comers report" %}</strong></a>
+                            <p class="grp-font-color-quiet">
+                                {% trans "Download a PDF summary of late arrivals for a selected date range." %}
+                            </p>
+                        </div>
+                    </div>
+                {% endif %}
+            {% endblock %}
+        </div>
+        <div class="g-d-6 g-d-l">
+            <div class="grp-module" id="grp-recent-actions-module">
+                <h2>{% trans 'Recent actions' %}</h2>
+                <div class="grp-module">
+                    <h3>{% trans 'My actions' %}</h3>
+                    {% get_admin_log 10 as admin_log for_user user %}
+                    {% if not admin_log %}
+                        <div class="grp-row"><p>{% trans 'None available' %}</p></div>
+                    {% else %}
+                        <ul class="grp-listing-small">
+                            {% for entry in admin_log %}
+                                <li class="grp-row{% if entry.is_addition %} grp-add-link{% endif %}{% if entry.is_change %} grp-change-link{% endif %}{% if entry.is_deletion %} grp-delete-link{% endif %}">
+                                    {% if entry.is_deletion %}
+                                        <span>{{ entry.object_repr }}</span>
+                                    {% else %}
+                                        <a href="{{ entry.get_admin_url }}">{{ entry.object_repr }}</a>
+                                    {% endif %}
+                                    <span class="grp-font-color-quiet">{% filter capfirst %}{% trans entry.content_type.name %}{% endfilter %}</span>
+                                </li>
+                            {% endfor %}
+                        </ul>
+                    {% endif %}
+                </div>
+            </div>
+        </div>
+    </div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- point the admin site at a custom dashboard template so we can surface reports
- add a reports module on the admin home that links to the late comers report

## Testing
- python manage.py test attendance.tests.test_reports --settings=config.settings.test

------
https://chatgpt.com/codex/tasks/task_e_68ca55c5d128832dbafd5674dae8dd87