### PR TITLE
Revamp late comers report layout

### DIFF
--- a/attendance/reports.py
+++ b/attendance/reports.py
@@ -7,14 +7,14 @@ from datetime import date
 from typing import Any, Dict, Iterable, List, Tuple
 
 from django.contrib.staticfiles import finders
-from django.db.models import Q
+from django.db.models import Q, Min
 from django.template.loader import render_to_string
 from django.utils import timezone
 from django.templatetags.static import static
 
 from weasyprint import HTML, CSS
 
-from .models import AttDay
+from .models import AttDay, AttPair
 
 
 def get_late_comers(
@@ -50,13 +50,36 @@ def get_late_comers(
     if shift_id:
         qs = qs.filter(shift_id=shift_id)
 
+    days = list(qs)
+    if not days:
+        return []
+
+    employee_ids = {day.employee_id for day in days}
+    punch_map: Dict[Tuple[int, date], Any] = {}
+    if employee_ids:
+        punches = (
+            AttPair.objects.filter(
+                employee_id__in=employee_ids, date__range=(start_date, end_date)
+            )
+            .values("employee_id", "date")
+            .annotate(first_in=Min("in_ts"))
+        )
+        punch_map = {
+            (punch["employee_id"], punch["date"]): punch["first_in"]
+            for punch in punches
+        }
+
     records: List[Dict[str, Any]] = []
-    for day in qs:
+    for day in days:
         branch = day.employee.branch
         records.append(
             {
                 "employee": f"{day.employee.first_name} {day.employee.last_name}".strip(),
+                "employee_id": day.employee_id,
                 "shift": getattr(day.shift, "name", ""),
+                "shift_start": getattr(day.shift, "start_time", None),
+                "shift_end": getattr(day.shift, "end_time", None),
+                "punch_in": punch_map.get((day.employee_id, day.date)),
                 "date": day.date,
                 "late_min": day.late_min,
                 "branch": getattr(branch, "name", "Unassigned"),

--- a/attendance/templates/reports/late_comers.html
+++ b/attendance/templates/reports/late_comers.html
@@ -3,53 +3,137 @@
 <head>
   <meta charset="utf-8" />
   <title>Late Comers Report</title>
+  <style>
+    body {
+      font-family: "Helvetica Neue", Arial, sans-serif;
+      margin: 32px;
+      color: #1f2933;
+    }
+
+    h1.report-title {
+      text-align: center;
+      font-size: 24px;
+      margin: 0 0 12px;
+      letter-spacing: 0.5px;
+    }
+
+    p.generated-at {
+      text-align: center;
+      margin: 0 0 24px;
+      color: #6b7280;
+      font-size: 12px;
+    }
+
+    section.branch-section {
+      margin-bottom: 32px;
+    }
+
+    h2.branch-name {
+      text-align: center;
+      font-size: 18px;
+      margin: 0 0 16px;
+      color: #374151;
+      letter-spacing: 0.3px;
+    }
+
+    table.report-table {
+      width: 100%;
+      border-collapse: collapse;
+      margin: 0 auto 16px;
+      font-size: 12px;
+    }
+
+    table.report-table th,
+    table.report-table td {
+      padding: 6px 10px;
+      text-align: left;
+      border-bottom: 1px solid #d1d5db;
+    }
+
+    table.report-table th {
+      font-weight: 600;
+      background-color: #f3f4f6;
+      color: #111827;
+    }
+
+    table.report-table tbody tr:last-child td {
+      border-bottom: none;
+    }
+
+    p.empty-branch,
+    p.empty-state {
+      text-align: center;
+      font-size: 12px;
+      color: #6b7280;
+      margin: 0;
+    }
+  </style>
 </head>
 <body>
-  <h1>Late Comers Report</h1>
-  <p>
-    Date:
+  {% if start_date and end_date %}
     {% if start_date == end_date %}
-      {{ start_date|date:"d M Y" }}
+      {% with report_period=start_date|date:"d M Y" %}
+        <h1 class="report-title">Late Comers Report - {{ report_period }}</h1>
+      {% endwith %}
     {% else %}
-      {{ start_date|date:"d M Y" }} - {{ end_date|date:"d M Y" }}
+      {% with start_label=start_date|date:"d M Y" end_label=end_date|date:"d M Y" %}
+        <h1 class="report-title">Late Comers Report - {{ start_label }} to {{ end_label }}</h1>
+      {% endwith %}
     {% endif %}
-  </p>
-  <table>
-    <thead>
-      <tr>
-        <th>Branch</th>
-        <th>Employee</th>
-        <th>Shift</th>
-        <th>Date</th>
-        <th>Late (min)</th>
-      </tr>
-    </thead>
-    <tbody>
-      {% if branches %}
-        {% for branch_name, branch in branches.items %}
-          {% if branch.records %}
-            {% for rec in branch.records %}
+  {% else %}
+    <h1 class="report-title">Late Comers Report</h1>
+  {% endif %}
+
+  {% if generated_at %}
+    <p class="generated-at">Generated on {{ generated_at|date:"d M Y H:i" }}</p>
+  {% endif %}
+
+  {% if branches %}
+    {% for branch_name, branch in branches.items %}
+      <section class="branch-section">
+        <h2 class="branch-name">{{ branch_name }}</h2>
+        {% if branch.records %}
+          <table class="report-table">
+            <thead>
               <tr>
-                <td>{{ branch_name }}</td>
-                <td>{{ rec.employee }}</td>
-                <td>{{ rec.shift|default:"-" }}</td>
-                <td>{{ rec.date|date:"d M Y" }}</td>
-                <td>{{ rec.late_min }}</td>
+                <th>Sr.No</th>
+                <th>Emp. ID</th>
+                <th>Name</th>
+                <th>Shift Time</th>
+                <th>Punch In Time</th>
               </tr>
-            {% endfor %}
-          {% else %}
-            <tr>
-              <td>{{ branch_name }}</td>
-              <td colspan="4">No late arrivals were recorded for this branch.</td>
-            </tr>
-          {% endif %}
-        {% endfor %}
-      {% else %}
-        <tr>
-          <td colspan="5">No late arrivals were recorded for the selected period.</td>
-        </tr>
-      {% endif %}
-    </tbody>
-  </table>
+            </thead>
+            <tbody>
+              {% for rec in branch.records %}
+                <tr>
+                  <td>{{ forloop.counter }}</td>
+                  <td>{{ rec.employee_id }}</td>
+                  <td>{{ rec.employee }}</td>
+                  <td>
+                    {% if rec.shift_start and rec.shift_end %}
+                      {{ rec.shift_start|time:"H:i" }} - {{ rec.shift_end|time:"H:i" }}
+                    {% else %}
+                      -
+                    {% endif %}
+                  </td>
+                  <td>
+                    {% if rec.punch_in %}
+                      {{ rec.punch_in|date:"H:i" }}
+                    {% else %}
+                      -
+                    {% endif %}
+                  </td>
+                </tr>
+              {% endfor %}
+            </tbody>
+          </table>
+        {% else %}
+          <p class="empty-branch">No late arrivals were recorded for this branch.</p>
+        {% endif %}
+      </section>
+    {% endfor %}
+  {% else %}
+    <p class="empty-state">No late arrivals were recorded for the selected period.</p>
+  {% endif %}
 </body>
 </html>

--- a/attendance/tests/test_reports.py
+++ b/attendance/tests/test_reports.py
@@ -1,6 +1,6 @@
 import io
 from collections import OrderedDict
-from datetime import date, datetime
+from datetime import date, datetime, time
 
 from django.test import TestCase
 from django.urls import reverse
@@ -14,6 +14,10 @@ from attendance.reports import get_late_comers, group_late_comers
 
 
 class LateComersReportTests(TestCase):
+    @staticmethod
+    def _normalize_time(value):
+        return time.fromisoformat(value) if isinstance(value, str) else value
+
     def setUp(self):
         self.company = Company.objects.create(name="C1")
         self.branch1 = Branch.objects.create(company=self.company, name="B1")
@@ -85,8 +89,16 @@ class LateComersReportTests(TestCase):
         assert len(filtered) == 1
         expected_emp1_name = f"{self.emp1.first_name} {self.emp1.last_name}".strip()
         expected_emp2_name = f"{self.emp2.first_name} {self.emp2.last_name}".strip()
+        expected_shift1_start = self._normalize_time(self.shift1.start_time)
+        expected_shift1_end = self._normalize_time(self.shift1.end_time)
+        expected_shift2_start = self._normalize_time(self.shift2.start_time)
+        expected_shift2_end = self._normalize_time(self.shift2.end_time)
         assert filtered[0]["employee"] == expected_emp1_name
         assert filtered[0]["branch"] == self.branch1.name
+        assert filtered[0]["employee_id"] == self.emp1.id
+        assert filtered[0]["shift_start"] == expected_shift1_start
+        assert filtered[0]["shift_end"] == expected_shift1_end
+        assert filtered[0]["punch_in"].time() == time(9, 15)
         branches, stats = group_late_comers(records)
         assert stats["total_late_min"] == 20
         assert set(branches.keys()) == {self.branch1.name, self.branch2.name}
@@ -96,6 +108,16 @@ class LateComersReportTests(TestCase):
         assert branches[self.branch2.name]["total_late_min"] == 5
         assert [r["employee"] for r in branch1_records] == [expected_emp1_name]
         assert [r["employee"] for r in branch2_records] == [expected_emp2_name]
+        alice_record = branch1_records[0]
+        bob_record = branch2_records[0]
+        assert alice_record["employee_id"] == self.emp1.id
+        assert alice_record["shift_start"] == expected_shift1_start
+        assert alice_record["shift_end"] == expected_shift1_end
+        assert alice_record["punch_in"].time() == time(9, 15)
+        assert bob_record["employee_id"] == self.emp2.id
+        assert bob_record["shift_start"] == expected_shift2_start
+        assert bob_record["shift_end"] == expected_shift2_end
+        assert bob_record["punch_in"].time() == time(10, 5)
 
     def test_late_comers_template_renders_simple_layout(self):
         generated_at = timezone.make_aware(datetime(2024, 1, 2, 9, 30))
@@ -107,7 +129,13 @@ class LateComersReportTests(TestCase):
                         "records": [
                             {
                                 "employee": "Alice Anderson",
+                                "employee_id": self.emp1.id,
                                 "shift": "S1",
+                                "shift_start": self._normalize_time(self.shift1.start_time),
+                                "shift_end": self._normalize_time(self.shift1.end_time),
+                                "punch_in": timezone.make_aware(
+                                    datetime(2024, 1, 1, 9, 15)
+                                ),
                                 "date": self.day,
                                 "late_min": 15,
                             }
@@ -121,7 +149,13 @@ class LateComersReportTests(TestCase):
                         "records": [
                             {
                                 "employee": "Bob Brown",
+                                "employee_id": self.emp2.id,
                                 "shift": "S2",
+                                "shift_start": self._normalize_time(self.shift2.start_time),
+                                "shift_end": self._normalize_time(self.shift2.end_time),
+                                "punch_in": timezone.make_aware(
+                                    datetime(2024, 1, 1, 10, 5)
+                                ),
                                 "date": self.day,
                                 "late_min": 5,
                             }
@@ -141,24 +175,22 @@ class LateComersReportTests(TestCase):
                 "total_late_min": 20,
             },
         )
-        # The simplified template should just show a heading, the selected date, and a basic table.
-        assert "<h1>Late Comers Report</h1>" in html
-        assert "Date:" in html
-        # When the start and end dates match, only a single date should be shown.
-        assert "01 Jan 2024" in html
-        assert " - " not in html
-        assert "<table>" in html
-        assert "<th>Branch</th>" in html
-        assert "<th>Employee</th>" in html
-        assert "<th>Shift</th>" in html
-        assert "<th>Date</th>" in html
-        assert "<th>Late (min)</th>" in html
-        assert f">{self.branch1.name}<" in html
-        assert f">{self.branch2.name}<" in html
+        assert "Late Comers Report - 01 Jan 2024" in html
+        assert f"<h2 class=\"branch-name\">{self.branch1.name}</h2>" in html
+        assert f"<h2 class=\"branch-name\">{self.branch2.name}</h2>" in html
+        assert "<th>Sr.No</th>" in html
+        assert "<th>Emp. ID</th>" in html
+        assert "<th>Name</th>" in html
+        assert "<th>Shift Time</th>" in html
+        assert "<th>Punch In Time</th>" in html
         assert "Alice Anderson" in html
         assert "Bob Brown" in html
-        assert "S1" in html and "S2" in html
-        assert "15" in html and "5" in html
+        assert f">{self.emp1.id}<" in html
+        assert f">{self.emp2.id}<" in html
+        assert "09:00 - 17:00" in html
+        assert "10:00 - 18:00" in html
+        assert "09:15" in html
+        assert "10:05" in html
 
     def test_api_late_comers_report(self):
         self.api_client.force_authenticate(self.admin)


### PR DESCRIPTION
## Summary
- enrich late comers report data with employee ids, shift timings, and punch in timestamps
- restyle the late comers HTML template with centered headings and a sleek table layout per branch
- update unit tests to validate the new report structure and time formatting

## Testing
- python manage.py test attendance.tests.test_reports


------
https://chatgpt.com/codex/tasks/task_e_68ca63af30e8832dafe0a0d1c5bf1198