### PR TITLE
Add admin attendance calendar view

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,150 @@ comprehensive automated test suite.
   the admin interface. See [docs/attendance_reports.md](docs/attendance_reports.md)
   for usage and query parameters.
 
+### Attendance calendar API
+
+Pagasys now exposes a calendar-centric attendance feed that merges the
+pre-computed `AttDay` outcomes, raw punch `AttPair` data, and manual
+`AttAdjustment` overrides into a month grid that front-end widgets can render
+without additional API calls. The routes follow the multitenant pattern used by
+other attendance endpoints and inherit the same role-based scope checks.
+
+#### Base endpoints
+
+* `GET /api/companies/{company_id}/attendance-calendar/?month=YYYY-MM`
+  returns a paginated collection of employees, each with per-day rows and a
+  summary footer for the requested month.
+* `GET /api/companies/{company_id}/attendance-calendar/{employee_id}/?month=YYYY-MM`
+  focuses the payload on a single employee, which is useful for detail panels
+  or drill-downs.
+
+Responses share the following structure:
+
+```json
+{
+  "month": "2024-05",
+  "days": ["2024-05-01", "2024-05-31"],
+  "employees": [
+    {
+      "id": 17,
+      "display": "Maria Gomez",
+      "metadata": {
+        "department": "Operations",
+        "project": "Project Falcon",
+        "branch": "Dubai Marina",
+        "code": "EMP-0017"
+      },
+      "rows": [
+        {
+          "date": "2024-05-01",
+          "status": "present",
+          "locked": true,
+          "locked_reason": "Attendance day is locked; adjustments are disabled.",
+          "metrics": {
+            "work_min": 480,
+            "unpaid_break_min": 0,
+            "paid_break_min": 60,
+            "late_min": 5,
+            "early_leave_min": 0,
+            "ot_regular_min": 45,
+            "ot_night_min": 0,
+            "ot_holiday_min": 0,
+            "on_leave": false,
+            "leave_portion": 0.0,
+            "is_holiday": false,
+            "is_rest_day": false,
+            "pairs_count": 2,
+            "punches_used": 4
+          },
+          "anomalies": {"missing_out_closed_at_next_in": 1},
+          "pairs": [
+            {
+              "id": 3001,
+              "employee": 17,
+              "date": "2024-05-01",
+              "in_ts": "2024-05-01T08:00:00+04:00",
+              "out_ts": "2024-05-01T12:00:00+04:00",
+              "duration_min": 240,
+              "source": "auto",
+              "anomaly": {}
+            }
+          ],
+          "adjustments": [
+            {
+              "id": 901,
+              "employee": 17,
+              "date": "2024-05-01",
+              "delta_work_min": -15,
+              "reason": "Late arrival waiver",
+              "created_by_id": 3,
+              "created_at": "2024-05-02T06:00:00Z"
+            }
+          ]
+        }
+      ],
+      "summary": {
+        "present": 18,
+        "absent": 2,
+        "leave": 1,
+        "holiday": 1,
+        "rest": 3,
+        "partial": 0,
+        "locked_days": 12,
+        "total_ot_min": 480
+      }
+    }
+  ],
+  "next": null,
+  "previous": null
+}
+```
+
+Every employee object exposes rich metadata (department, project, branch, and
+code) and daily rows include the canonical metrics surfaced by `AttDay`. When
+the `include_pairs` or `include_adjustments` query flags are enabled, the API
+embeds the full serializer output for `AttPair` and `AttAdjustment` models so UI
+clients can build punch-by-punch or adjustment history panels without chaining
+requests. Setting `include_anomalies=false` suppresses the anomaly dictionary to
+trim payload size. Use `stats_only=true` to omit the `rows` array entirely and
+return only the monthly `summary` object for each employee.
+
+#### Query parameters
+
+* `month=YYYY-MM` (required) expands to the first and last day of the month.
+* `include_pairs`, `include_adjustments`, `include_anomalies`, and
+  `stats_only` toggle optional sections of the payload.
+* `status=present,leave` filters to specific `AttDay.status` values before
+  building the grid and summary counts.
+* `locked=true|false` restricts the response to days in a particular lock state.
+* `employee`, `branch`, `department`, and `project` accept either comma-separated
+  identifiers or repeated query parameters to limit the employee set.
+* `search` performs case-insensitive matching across employee name, username,
+  email, department, project, and associated branch names. Multiple terms must
+  all match (for example `search=alice ops`).
+* `sort=department,-name` controls employee ordering using the same syntax as
+  DRF's `ordering` filter. Pagination honours this ordering and falls back to
+  `first_name`, `last_name`, `username`, and `id`.
+* Cursor pagination is enabled with a hard limit of 200 employees per page; the
+  response includes `next`/`previous` links when additional pages are available.
+
+#### Locking and adjustments
+
+The calendar viewset exposes helper actions so managers can complete their
+workflow without swapping endpoints:
+
+* `POST /api/companies/{company_id}/attendance-calendar/lock` accepts the same
+  payload as `LockDaysSerializer` (`start`, `end`, optional `employee_ids`, and
+  `locked`) and wraps the transactional bulk update already used by
+  `AttDayViewSet.lock`. The response returns `{ "updated": <count> }`.
+* `POST /api/companies/{company_id}/attendance-calendar/adjustments` proxies the
+  `AttAdjustmentViewSet` create action. Successful requests return the created
+  adjustment with the acting user's ID stamped in `created_by_id`.
+
+Locked days automatically surface a `locked_reason` message in the daily payload
+to warn UI clients that adjustments are prohibited. Because adjustments cannot
+touch locked days, callers should respect this flag before opening edit modals.
+
+
 ### Roster scheduling
 
 Use `/api/companies/{cid}/roster/schedule-range/` to assign shifts to an entire

--- a/attendance/admin.py
+++ b/attendance/admin.py
@@ -1,4 +1,5 @@
-from datetime import timedelta
+from datetime import date, timedelta
+from urllib.parse import urlsplit
 
 from django.contrib import admin, messages
 from django.utils.safestring import mark_safe
@@ -7,6 +8,10 @@ from django.template.response import TemplateResponse
 from django.shortcuts import redirect
 from django.urls import path
 from django.http import HttpResponse
+from django.utils import timezone
+
+from rest_framework import serializers
+from rest_framework.request import Request
 
 from pagasys.admin import ScopedAdminMixin
 from pagasys.models import Branch, Department, Employee, Project, ShiftTemplate
@@ -14,6 +19,12 @@ from pagasys.utils import scope_queryset
 from .models import AttDay, AttPair, AttAdjustment, LeaveRequest, LeaveDay
 from .tasks import compute_employee_day_task, recompute_range_task
 from .reports import get_late_comers, group_late_comers, render_late_comers_pdf
+from .views import (
+    AttendanceCalendarViewSet,
+    CALENDAR_PAGE_SIZE,
+    parse_bool,
+    parse_month,
+)
 
 
 class AttAdjustmentForm(forms.ModelForm):
@@ -47,6 +58,310 @@ class AttDayAdmin(ScopedAdminMixin, admin.ModelAdmin):
         "unlock_selected",
         "manual_recompute",
     ]
+
+    @staticmethod
+    def _format_validation_error(exc):
+        detail = getattr(exc, "detail", exc)
+        if isinstance(detail, dict):
+            parts = []
+            for key, value in detail.items():
+                if isinstance(value, (list, tuple)):
+                    message = ", ".join(str(item) for item in value)
+                else:
+                    message = str(value)
+                if key:
+                    parts.append(f"{key}: {message}")
+                else:
+                    parts.append(message)
+            return "; ".join(parts)
+        if isinstance(detail, (list, tuple)):
+            return "; ".join(str(item) for item in detail)
+        return str(detail)
+
+    @staticmethod
+    def _relative_link(link):
+        if not link:
+            return None
+        parts = urlsplit(link)
+        path = parts.path
+        if parts.query:
+            path = f"{path}?{parts.query}"
+        return path
+
+    def _parse_bool_param(self, request, name, *, default=False):
+        value = request.GET.get(name)
+        if value is None:
+            return default
+        try:
+            return parse_bool(value, default=default)
+        except serializers.ValidationError:
+            self.message_user(
+                request,
+                f"Invalid value for '{name}'. Using default.",
+                level=messages.WARNING,
+            )
+            return default
+
+    def calendar_view(self, request):
+        query = request.GET.copy()
+        default_month = timezone.localdate().strftime("%Y-%m")
+
+        def redirect_with_params(params):
+            encoded = params.urlencode()
+            if encoded:
+                return redirect(f"{request.path}?{encoded}")
+            return redirect(request.path)
+
+        if not query.get("month"):
+            query["month"] = default_month
+            if "cursor" in query:
+                del query["cursor"]
+            return redirect_with_params(query)
+
+        month_value = query.get("month")
+        try:
+            start, end = parse_month(month_value)
+        except serializers.ValidationError as exc:
+            self.message_user(
+                request,
+                self._format_validation_error(exc),
+                level=messages.ERROR,
+            )
+            query["month"] = default_month
+            if "cursor" in query:
+                del query["cursor"]
+            return redirect_with_params(query)
+
+        include_pairs = self._parse_bool_param(
+            request, "include_pairs", default=False
+        )
+        include_adjustments = self._parse_bool_param(
+            request, "include_adjustments", default=False
+        )
+        include_anomalies = self._parse_bool_param(
+            request, "include_anomalies", default=True
+        )
+
+        stats_only = False
+        if request.GET.get("stats_only") is not None:
+            try:
+                requested_stats = parse_bool(request.GET.get("stats_only"))
+            except serializers.ValidationError:
+                self.message_user(
+                    request,
+                    "Invalid value for 'stats_only'. Showing full calendar instead.",
+                    level=messages.WARNING,
+                )
+            else:
+                if requested_stats:
+                    self.message_user(
+                        request,
+                        "Stats-only mode is not available in the admin calendar view. Displaying the full grid.",
+                        level=messages.INFO,
+                    )
+
+        status_param = request.GET.get("status")
+        status_filters = (
+            [value.strip() for value in status_param.split(",") if value.strip()]
+            if status_param
+            else []
+        )
+
+        locked_filter = None
+        if "locked" in request.GET:
+            try:
+                locked_filter = parse_bool(request.GET.get("locked"))
+            except serializers.ValidationError:
+                self.message_user(
+                    request,
+                    "Invalid value for 'locked'. Showing all days.",
+                    level=messages.WARNING,
+                )
+                locked_filter = None
+
+        viewset = AttendanceCalendarViewSet()
+        drf_request = Request(request)
+        drf_request.user = request.user
+        viewset.request = drf_request
+        viewset.args = []
+        viewset.kwargs = {}
+        viewset.action = "list"
+        viewset.format_kwarg = None
+
+        queryset = viewset._filter_employees(viewset.get_queryset(), drf_request, None)
+        queryset = viewset._apply_sorting(queryset, drf_request)
+
+        page = viewset.paginate_queryset(queryset)
+        employees = []
+        using_pagination = False
+        if page is not None:
+            employees = list(page)
+            using_pagination = True
+            if not employees and queryset.exists():
+                employees = list(queryset[:CALENDAR_PAGE_SIZE])
+                using_pagination = False
+        else:
+            employees = list(queryset[:CALENDAR_PAGE_SIZE])
+
+        if not using_pagination and len(employees) > CALENDAR_PAGE_SIZE:
+            employees = employees[:CALENDAR_PAGE_SIZE]
+
+        payload = viewset._build_calendar_response(
+            employees,
+            start,
+            end,
+            include_pairs=include_pairs,
+            include_adjustments=include_adjustments,
+            include_anomalies=include_anomalies,
+            stats_only=stats_only,
+            status_filters=status_filters,
+            locked_filter=locked_filter,
+        )
+
+        paginator = getattr(viewset, "paginator", None)
+        next_link = previous_link = None
+        if paginator and using_pagination:
+            next_link = self._relative_link(paginator.get_next_link())
+            previous_link = self._relative_link(paginator.get_previous_link())
+
+        days_context = []
+        for iso_day in payload.get("days", []):
+            current = date.fromisoformat(iso_day)
+            days_context.append(
+                {
+                    "iso": iso_day,
+                    "date": current,
+                    "weekday": current.strftime("%a"),
+                    "is_weekend": current.weekday() >= 5,
+                }
+            )
+
+        employees_context = []
+        for item in payload.get("employees", []):
+            metadata = item.get("metadata") or {}
+            summary = item.get("summary") or {}
+            rows = []
+            for row in item.get("rows", []):
+                metrics = row.get("metrics", {})
+                total_ot = (
+                    metrics.get("ot_regular_min", 0)
+                    + metrics.get("ot_night_min", 0)
+                    + metrics.get("ot_holiday_min", 0)
+                )
+                status_value = row.get("status")
+                status_class = (status_value or "empty").replace("_", "-")
+                status_display = (
+                    status_value.replace("_", " ").title() if status_value else "—"
+                )
+                rows.append(
+                    {
+                        **row,
+                        "total_ot": total_ot,
+                        "metrics": metrics,
+                        "anomalies": row.get("anomalies", {}),
+                        "pairs": row.get("pairs", []),
+                        "adjustments": row.get("adjustments", []),
+                        "status_class": status_class,
+                        "status_display": status_display,
+                    }
+                )
+
+            metadata_tags = []
+            if metadata.get("department"):
+                metadata_tags.append({"label": metadata["department"], "name": "Department"})
+            if metadata.get("project"):
+                metadata_tags.append({"label": metadata["project"], "name": "Project"})
+            if metadata.get("branch"):
+                metadata_tags.append({"label": metadata["branch"], "name": "Branch"})
+
+            summary_definitions = [
+                ("present", "Present", "present"),
+                ("absent", "Absent", "absent"),
+                ("leave", "Leave", "leave"),
+                ("holiday", "Holiday", "holiday"),
+                ("rest", "Rest day", "rest"),
+                ("partial", "Partial", "partial"),
+            ]
+            summary_items = []
+            for key, label, css in summary_definitions:
+                value = summary.get(key, 0)
+                summary_items.append(
+                    {
+                        "key": key,
+                        "label": label,
+                        "value": value,
+                        "css": css,
+                        "is_zero": value == 0,
+                    }
+                )
+            summary_items.append(
+                {
+                    "key": "locked_days",
+                    "label": "Locked",
+                    "value": summary.get("locked_days", 0),
+                    "css": "locked",
+                    "is_zero": summary.get("locked_days", 0) == 0,
+                }
+            )
+            summary_items.append(
+                {
+                    "key": "total_ot_min",
+                    "label": "OT min",
+                    "value": summary.get("total_ot_min", 0),
+                    "css": "ot",
+                    "is_zero": summary.get("total_ot_min", 0) == 0,
+                }
+            )
+
+            employees_context.append(
+                {
+                    "id": item.get("id"),
+                    "display": item.get("display"),
+                    "metadata": metadata,
+                    "metadata_tags": metadata_tags,
+                    "code": metadata.get("code"),
+                    "rows": rows,
+                    "summary": summary,
+                    "summary_items": summary_items,
+                }
+            )
+
+        hidden_params = []
+        excluded = {
+            "month",
+            "search",
+            "include_pairs",
+            "include_adjustments",
+            "include_anomalies",
+            "cursor",
+            "stats_only",
+        }
+        for key, values in request.GET.lists():
+            if key in excluded:
+                continue
+            for value in values:
+                hidden_params.append((key, value))
+
+        context = {
+            "title": "Attendance calendar",
+            "month_value": start.strftime("%Y-%m"),
+            "month_display": start.strftime("%B %Y"),
+            "days": days_context,
+            "employees": employees_context,
+            "employee_count": len(employees_context),
+            "include_pairs": include_pairs,
+            "include_adjustments": include_adjustments,
+            "include_anomalies": include_anomalies,
+            "search_value": request.GET.get("search", ""),
+            "hidden_params": hidden_params,
+            "next_link": next_link,
+            "previous_link": previous_link,
+            "page_size": CALENDAR_PAGE_SIZE,
+        }
+
+        return TemplateResponse(
+            request, "admin/attendance/attday/calendar.html", context
+        )
 
     class ManualRecomputeForm(forms.Form):
         start = forms.DateField()
@@ -192,6 +507,11 @@ class AttDayAdmin(ScopedAdminMixin, admin.ModelAdmin):
     def get_urls(self):
         urls = super().get_urls()
         custom = [
+            path(
+                "calendar/",
+                self.admin_site.admin_view(self.calendar_view),
+                name="attendance_attday_calendar",
+            ),
             path(
                 "manual-recompute/",
                 self.admin_site.admin_view(self.manual_recompute_view),

--- a/attendance/static/attendance/admin-calendar.css
+++ b/attendance/static/attendance/admin-calendar.css
@@ -1,0 +1,468 @@
+.attendance-calendar-page {
+  background: #ffffff;
+  border: 1px solid #e2e8f0;
+  border-radius: 16px;
+  padding: 24px;
+  box-shadow: 0 16px 40px rgba(15, 23, 42, 0.08);
+}
+
+.calendar-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 24px;
+  margin-bottom: 24px;
+}
+
+.calendar-header h1 {
+  margin: 0;
+  font-size: 26px;
+  font-weight: 700;
+  color: #0f172a;
+}
+
+.calendar-subtitle {
+  margin: 4px 0 0;
+  font-size: 15px;
+  color: #64748b;
+}
+
+.calendar-meta {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  align-items: flex-end;
+  font-size: 13px;
+  color: #475569;
+}
+
+.calendar-meta span {
+  background: #f1f5f9;
+  padding: 4px 10px;
+  border-radius: 999px;
+}
+
+.calendar-filters {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 18px;
+  padding: 18px;
+  background: #f8fafc;
+  border: 1px solid #e2e8f0;
+  border-radius: 14px;
+  margin-bottom: 24px;
+}
+
+.calendar-filters .field-group {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.calendar-filters label {
+  font-weight: 600;
+  font-size: 13px;
+  color: #1e293b;
+}
+
+.calendar-filters input[type="month"],
+.calendar-filters input[type="text"] {
+  width: 100%;
+  border: 1px solid #cbd5f5;
+  border-radius: 10px;
+  padding: 8px 12px;
+  font-size: 13px;
+  background: #ffffff;
+  color: #0f172a;
+  box-shadow: inset 0 1px 2px rgba(15, 23, 42, 0.05);
+}
+
+.calendar-filters input[type="text"]::placeholder {
+  color: #94a3b8;
+}
+
+.calendar-filters .checkbox-group {
+  gap: 10px;
+  padding-top: 4px;
+}
+
+.calendar-filters .checkbox-group label {
+  font-weight: 500;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.calendar-filters .field-actions {
+  align-items: flex-end;
+  justify-content: flex-end;
+}
+
+.calendar-filters .field-actions,
+.calendar-filters .checkbox-group {
+  display: flex;
+  flex-direction: column;
+}
+
+.calendar-filters .button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 999px;
+  padding: 8px 16px;
+  font-weight: 600;
+  text-decoration: none;
+  border: none;
+  cursor: pointer;
+}
+
+.calendar-filters .button-primary {
+  background: #2563eb;
+  color: #ffffff;
+  box-shadow: 0 8px 20px rgba(37, 99, 235, 0.3);
+}
+
+.calendar-filters .button-secondary {
+  background: #e2e8f0;
+  color: #0f172a;
+}
+
+.calendar-table-wrapper {
+  overflow-x: auto;
+  border: 1px solid #e2e8f0;
+  border-radius: 16px;
+}
+
+.calendar-table {
+  width: 100%;
+  min-width: 960px;
+  border-collapse: separate;
+  border-spacing: 0;
+  font-size: 12px;
+}
+
+.calendar-table thead th {
+  background: #f8fafc;
+  color: #475569;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  border-bottom: 1px solid #e2e8f0;
+  padding: 12px 10px;
+}
+
+.calendar-table .employee-col {
+  width: 280px;
+  position: sticky;
+  left: 0;
+  z-index: 3;
+  background: #f8fafc;
+  border-right: 1px solid #e2e8f0;
+}
+
+.calendar-table tbody th.employee-info {
+  position: sticky;
+  left: 0;
+  z-index: 2;
+  background: linear-gradient(90deg, #ffffff 0%, #f8fafc 100%);
+  border-right: 1px solid #e2e8f0;
+  padding: 16px;
+  min-width: 280px;
+}
+
+.calendar-table th,
+.calendar-table td {
+  border: 1px solid #e2e8f0;
+  padding: 12px 8px;
+  vertical-align: top;
+}
+
+.calendar-table tbody tr:nth-child(even) th.employee-info {
+  background: linear-gradient(90deg, #ffffff 0%, #f1f5f9 100%);
+}
+
+.employee-name {
+  font-size: 15px;
+  font-weight: 600;
+  color: #0f172a;
+}
+
+.employee-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 8px;
+  font-size: 12px;
+  color: #475569;
+}
+
+.employee-meta span {
+  background: #f1f5f9;
+  padding: 4px 10px;
+  border-radius: 999px;
+}
+
+.employee-summary {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 12px;
+}
+
+.summary-chip {
+  padding: 4px 10px;
+  border-radius: 999px;
+  font-size: 11px;
+  font-weight: 600;
+  border: 1px solid transparent;
+}
+
+.summary-chip.present {
+  background: rgba(34, 197, 94, 0.12);
+  border-color: rgba(34, 197, 94, 0.35);
+  color: #166534;
+}
+
+.summary-chip.absent {
+  background: rgba(239, 68, 68, 0.12);
+  border-color: rgba(239, 68, 68, 0.35);
+  color: #991b1b;
+}
+
+.summary-chip.leave {
+  background: rgba(234, 179, 8, 0.16);
+  border-color: rgba(234, 179, 8, 0.35);
+  color: #92400e;
+}
+
+.summary-chip.holiday {
+  background: rgba(59, 130, 246, 0.14);
+  border-color: rgba(59, 130, 246, 0.32);
+  color: #1d4ed8;
+}
+
+.summary-chip.rest {
+  background: rgba(148, 163, 184, 0.16);
+  border-color: rgba(148, 163, 184, 0.32);
+  color: #475569;
+}
+
+.summary-chip.partial {
+  background: rgba(251, 191, 36, 0.16);
+  border-color: rgba(251, 191, 36, 0.32);
+  color: #b45309;
+}
+
+.summary-chip.locked {
+  background: rgba(15, 23, 42, 0.08);
+  border-color: rgba(15, 23, 42, 0.2);
+  color: #0f172a;
+}
+
+.summary-chip.ot {
+  background: rgba(129, 140, 248, 0.18);
+  border-color: rgba(129, 140, 248, 0.38);
+  color: #4338ca;
+}
+
+.summary-chip.is-zero {
+  opacity: 0.6;
+}
+
+.day-col {
+  min-width: 82px;
+  text-align: center;
+  background: #ffffff;
+}
+
+.day-col.weekend {
+  background: #eef2ff;
+}
+
+.day-number {
+  display: block;
+  font-size: 14px;
+  font-weight: 700;
+  color: #1e293b;
+}
+
+.day-weekday {
+  display: block;
+  font-size: 11px;
+  color: #64748b;
+}
+
+.calendar-cell {
+  min-width: 82px;
+  height: 96px;
+  position: relative;
+  text-align: center;
+  border-radius: 12px;
+  background: #ffffff;
+  overflow: hidden;
+}
+
+.calendar-cell .status-label {
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: #1e293b;
+  margin-bottom: 6px;
+}
+
+.calendar-cell .metric-line {
+  display: flex;
+  justify-content: center;
+  gap: 6px;
+  flex-wrap: wrap;
+  font-size: 11px;
+  color: #475569;
+}
+
+.calendar-cell .metric-line .metric {
+  padding: 2px 6px;
+  border-radius: 999px;
+  background: rgba(241, 245, 249, 0.8);
+}
+
+.calendar-cell .metric-line .metric.late {
+  background: rgba(254, 215, 170, 0.8);
+  color: #b45309;
+}
+
+.calendar-cell .metric-line .metric.ot {
+  background: rgba(191, 219, 254, 0.9);
+  color: #1d4ed8;
+  font-weight: 600;
+}
+
+.calendar-cell .cell-icons {
+  position: absolute;
+  top: 6px;
+  right: 6px;
+  display: flex;
+  gap: 4px;
+  font-size: 12px;
+}
+
+.calendar-cell .icon {
+  display: inline-flex;
+  align-items: center;
+}
+
+.calendar-cell.status-present {
+  background: #ecfdf5;
+  color: #065f46;
+}
+
+.calendar-cell.status-absent {
+  background: #fef2f2;
+  color: #b91c1c;
+}
+
+.calendar-cell.status-leave {
+  background: #fefce8;
+  color: #b45309;
+}
+
+.calendar-cell.status-holiday {
+  background: #eff6ff;
+  color: #1d4ed8;
+}
+
+.calendar-cell.status-rest {
+  background: #f8fafc;
+  color: #334155;
+}
+
+.calendar-cell.status-partial {
+  background: #fff7ed;
+  color: #c2410c;
+}
+
+.calendar-cell.status-empty {
+  background: #f1f5f9;
+  color: #94a3b8;
+}
+
+.calendar-cell.is-locked {
+  box-shadow: inset 0 0 0 2px rgba(30, 41, 59, 0.25);
+}
+
+.calendar-cell.has-anomalies {
+  box-shadow: inset 0 0 0 2px rgba(249, 115, 22, 0.45);
+}
+
+.calendar-table tbody tr:nth-child(even) td {
+  background: rgba(248, 250, 252, 0.6);
+}
+
+.calendar-table tbody tr:hover td {
+  background: rgba(219, 234, 254, 0.6);
+}
+
+.empty-state {
+  padding: 60px 20px;
+  text-align: center;
+  border: 2px dashed #cbd5f5;
+  border-radius: 16px;
+  background: #f8fafc;
+  color: #475569;
+}
+
+.empty-state h2 {
+  margin-bottom: 8px;
+  font-size: 20px;
+  color: #0f172a;
+}
+
+.calendar-pagination {
+  display: flex;
+  justify-content: flex-end;
+  gap: 12px;
+  margin-top: 28px;
+}
+
+.calendar-pagination .button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 8px 18px;
+  border-radius: 999px;
+  font-weight: 600;
+  text-decoration: none;
+  border: none;
+  cursor: pointer;
+}
+
+.calendar-pagination .button-primary {
+  background: #1d4ed8;
+  color: #ffffff;
+  box-shadow: 0 10px 24px rgba(29, 78, 216, 0.35);
+}
+
+.calendar-pagination .button-secondary {
+  background: #e2e8f0;
+  color: #0f172a;
+}
+
+@media (max-width: 1024px) {
+  .attendance-calendar-page {
+    padding: 18px;
+  }
+
+  .calendar-header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .calendar-meta {
+    width: 100%;
+    align-items: flex-start;
+  }
+
+  .calendar-filters {
+    grid-template-columns: 1fr;
+  }
+}

--- a/attendance/templates/admin/attendance/attday/calendar.html
+++ b/attendance/templates/admin/attendance/attday/calendar.html
@@ -1,0 +1,117 @@
+{% extends "admin/base_site.html" %}
+{% load static %}
+
+{% block extrastyle %}
+{{ block.super }}
+<link rel="stylesheet" type="text/css" href="{% static 'attendance/admin-calendar.css' %}">
+{% endblock %}
+
+{% block content %}
+<div class="attendance-calendar-page">
+  <div class="calendar-header">
+    <div>
+      <h1>{{ title }}</h1>
+      <p class="calendar-subtitle">{{ month_display }}</p>
+    </div>
+    <div class="calendar-meta">
+      <span class="calendar-count">Showing {{ employee_count }} employees</span>
+      <span class="calendar-page-size">Page size {{ page_size }}</span>
+    </div>
+  </div>
+
+  <form method="get" class="calendar-filters">
+    <div class="field-group">
+      <label for="id_month">Month</label>
+      <input type="month" id="id_month" name="month" value="{{ month_value }}">
+    </div>
+    <div class="field-group">
+      <label for="id_search">Search</label>
+      <input type="text" id="id_search" name="search" value="{{ search_value }}" placeholder="Search name, code, department…">
+    </div>
+    <div class="field-group checkbox-group">
+      <label><input type="checkbox" name="include_pairs" value="true"{% if include_pairs %} checked{% endif %}> Include pairs</label>
+      <label><input type="checkbox" name="include_adjustments" value="true"{% if include_adjustments %} checked{% endif %}> Include adjustments</label>
+      <label><input type="checkbox" name="include_anomalies" value="true"{% if include_anomalies %} checked{% endif %}> Include anomalies</label>
+    </div>
+    {% for key, value in hidden_params %}
+      <input type="hidden" name="{{ key }}" value="{{ value }}">
+    {% endfor %}
+    <div class="field-group field-actions">
+      <button type="submit" class="button button-primary">Apply filters</button>
+      <a class="button button-secondary" href="?month={{ month_value }}">Reset</a>
+    </div>
+  </form>
+
+  {% if employees %}
+  <div class="calendar-table-wrapper">
+    <table class="calendar-table">
+      <thead>
+        <tr>
+          <th class="employee-col">Employee</th>
+          {% for day in days %}
+          <th class="day-col{% if day.is_weekend %} weekend{% endif %}">
+            <span class="day-number">{{ day.date|date:"j" }}</span>
+            <span class="day-weekday">{{ day.date|date:"D" }}</span>
+          </th>
+          {% endfor %}
+        </tr>
+      </thead>
+      <tbody>
+        {% for employee in employees %}
+        <tr class="employee-row">
+          <th scope="row" class="employee-info">
+            <div class="employee-name">{{ employee.display }}</div>
+            <div class="employee-meta">
+              {% for tag in employee.metadata_tags %}
+              <span><strong>{{ tag.name }}:</strong> {{ tag.label }}</span>
+              {% endfor %}
+              <span class="employee-code"><strong>Code:</strong> {{ employee.code }}</span>
+            </div>
+            <div class="employee-summary">
+              {% for item in employee.summary_items %}
+              <span class="summary-chip {{ item.css }}{% if item.is_zero %} is-zero{% endif %}">{{ item.label }}: {{ item.value }}</span>
+              {% endfor %}
+            </div>
+          </th>
+          {% for row in employee.rows %}
+          <td class="calendar-cell status-{{ row.status_class }}{% if row.locked %} is-locked{% endif %}{% if row.anomalies %} has-anomalies{% endif %}"
+              title="{{ row.date }}&#10;Status: {{ row.status_display }}&#10;Work: {{ row.metrics.work_min }} min&#10;Late: {{ row.metrics.late_min }} min&#10;Overtime: {{ row.total_ot }} min">
+            <div class="cell-icons">
+              {% if row.locked %}<span class="icon" title="{{ row.locked_reason }}">🔒</span>{% endif %}
+              {% if row.adjustments %}<span class="icon" title="{{ row.adjustments|length }} adjustment{% if row.adjustments|length != 1 %}s{% endif %}">✏️</span>{% endif %}
+              {% if row.pairs %}<span class="icon" title="{{ row.pairs|length }} pair{% if row.pairs|length != 1 %}s{% endif %}">⏱</span>{% endif %}
+            </div>
+            <div class="status-label">{{ row.status_display }}</div>
+            <div class="metric-line">
+              <span class="metric">Work {{ row.metrics.work_min }}m</span>
+              {% if row.metrics.late_min %}
+              <span class="metric late">Late {{ row.metrics.late_min }}m</span>
+              {% endif %}
+              {% if row.total_ot %}
+              <span class="metric ot">OT {{ row.total_ot }}m</span>
+              {% endif %}
+            </div>
+          </td>
+          {% endfor %}
+        </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </div>
+  {% else %}
+  <div class="empty-state">
+    <h2>No employees found</h2>
+    <p>Try adjusting your filters or search query.</p>
+  </div>
+  {% endif %}
+
+  <div class="calendar-pagination">
+    {% if previous_link %}
+    <a class="button button-secondary" href="{{ previous_link }}">&larr; Previous</a>
+    {% endif %}
+    {% if next_link %}
+    <a class="button button-primary" href="{{ next_link }}">Next &rarr;</a>
+    {% endif %}
+  </div>
+</div>
+{% endblock %}

--- a/attendance/templates/admin/attendance/attday/change_list.html
+++ b/attendance/templates/admin/attendance/attday/change_list.html
@@ -1,5 +1,6 @@
 {% extends "admin/change_list.html" %}
 {% block object-tools-items %}
+<li><a class="button" href="{% url 'admin:attendance_attday_calendar' %}">Calendar view</a></li>
 <li><a class="button" href="{% url 'admin:attendance_attday_manual_recompute' %}">Manual recompute</a></li>
 <li><a class="button" href="{% url 'admin:attendance_attday_late_comers_report' %}">Late Comers report</a></li>
 {{ block.super }}

--- a/attendance/tests/test_attday_admin.py
+++ b/attendance/tests/test_attday_admin.py
@@ -1,6 +1,125 @@
+from datetime import date, datetime
+
+from django.test import TestCase, RequestFactory
+from django.utils import timezone
+from django.contrib import admin
+
+from pagasys.models import Company, Branch, Department, Project, Employee
+from attendance.models import AttDay, AttPair, AttAdjustment
 from attendance.admin import AttDayAdmin
 
 
 def test_attday_admin_includes_date_filter():
     assert "date" in AttDayAdmin.list_filter
     assert AttDayAdmin.date_hierarchy == "date"
+
+
+class AttendanceCalendarAdminViewTests(TestCase):
+    def setUp(self):
+        self.company = Company.objects.create(name="ACME")
+        self.branch = Branch.objects.create(company=self.company, name="HQ")
+        self.department = Department.objects.create(branch=self.branch, name="Ops")
+        self.project = Project.objects.create(
+            branch=self.branch,
+            name="Site A",
+            start_date=date(2024, 1, 1),
+        )
+        self.admin = Employee.objects.create_superuser(
+            username="admin",
+            password="pass",
+            department=self.department,
+            hire_date=date(2024, 1, 1),
+            employment_type="permanent",
+            visa_type="personal",
+            is_staff=True,
+        )
+        self.employee = Employee.objects.create_user(
+            username="emp1",
+            password="pass",
+            first_name="Alice",
+            last_name="Anderson",
+            department=self.department,
+            hire_date=date(2024, 1, 1),
+            employment_type="permanent",
+            visa_type="personal",
+        )
+
+        self.day_one = date(2024, 5, 1)
+        self.day_two = date(2024, 5, 2)
+
+        AttDay.objects.create(
+            employee=self.employee,
+            date=self.day_one,
+            work_min=480,
+            late_min=5,
+            ot_regular_min=60,
+            status="present",
+            anomalies={"missing_out_closed_at_next_in": 1},
+        )
+        AttDay.objects.create(
+            employee=self.employee,
+            date=self.day_two,
+            status="absent",
+        )
+
+        AttPair.objects.create(
+            employee=self.employee,
+            date=self.day_one,
+            in_event_id=100,
+            out_event_id=101,
+            in_ts=timezone.make_aware(datetime(2024, 5, 1, 8, 0)),
+            out_ts=timezone.make_aware(datetime(2024, 5, 1, 16, 0)),
+            duration_min=480,
+        )
+
+        AttAdjustment.objects.create(
+            employee=self.employee,
+            date=self.day_one,
+            delta_work_min=-15,
+            reason="Late arrival waiver",
+            created_by_id=self.admin.id,
+        )
+
+        AttDay.objects.filter(employee=self.employee, date=self.day_one).update(locked=True)
+
+        self.factory = RequestFactory()
+        self.attday_admin = AttDayAdmin(AttDay, admin.site)
+
+    def test_calendar_view_redirects_to_current_month_when_missing(self):
+        request = self.factory.get("/admin/attendance/attday/calendar/")
+        request.user = self.admin
+        request._cached_user = self.admin
+        response = self.attday_admin.calendar_view(request)
+        assert response.status_code == 302
+        assert "month=" in response["Location"]
+
+    def test_calendar_view_renders_calendar_grid(self):
+        request = self.factory.get(
+            "/admin/attendance/attday/calendar/",
+            {
+                "month": "2024-05",
+                "include_pairs": "true",
+                "include_adjustments": "true",
+            },
+        )
+        request.user = self.admin
+        request._cached_user = self.admin
+        response = self.attday_admin.calendar_view(request)
+        response.render()
+        assert response.status_code == 200
+        context = response.context_data
+        employees = context["employees"]
+        assert employees, context
+        alice = next(emp for emp in employees if emp["display"] == "Alice Anderson")
+        assert alice["summary"]["present"] == 1
+        assert alice["summary"]["locked_days"] == 1
+        rows = {row["date"]: row for row in alice["rows"]}
+        may_first = rows["2024-05-01"]
+        assert may_first["status_display"] == "Present"
+        assert may_first["metrics"]["work_min"] == 480
+        assert may_first["metrics"]["late_min"] == 5
+        assert may_first["total_ot"] == 60
+        assert may_first["locked"] is True
+        assert may_first["pairs"]
+        assert may_first["adjustments"]
+        assert may_first["anomalies"] == {"missing_out_closed_at_next_in": 1}

--- a/attendance/tests/test_attendance_calendar_viewset.py
+++ b/attendance/tests/test_attendance_calendar_viewset.py
@@ -1,0 +1,262 @@
+from datetime import date, datetime
+
+from django.test import TestCase
+from django.urls import reverse
+from django.utils import timezone
+from rest_framework.test import APIClient
+
+from pagasys.models import Company, Branch, Department, Project, Employee
+from attendance.models import AttDay, AttPair, AttAdjustment
+
+
+class AttendanceCalendarViewSetTests(TestCase):
+    def setUp(self):
+        self.client = APIClient()
+        self.company = Company.objects.create(name="ACME")
+        self.branch = Branch.objects.create(company=self.company, name="HQ")
+        self.department = Department.objects.create(branch=self.branch, name="Ops")
+        self.project = Project.objects.create(
+            branch=self.branch,
+            name="Site A",
+            start_date=date(2024, 1, 1),
+        )
+        self.admin = Employee.objects.create_superuser(
+            username="admin",
+            password="pass",
+            department=self.department,
+            hire_date=date(2024, 1, 1),
+            employment_type="permanent",
+            visa_type="personal",
+            is_staff=True,
+        )
+        self.employee_dept = Employee.objects.create_user(
+            username="emp1",
+            password="pass",
+            first_name="Alice",
+            last_name="Anderson",
+            department=self.department,
+            hire_date=date(2024, 1, 1),
+            employment_type="permanent",
+            visa_type="personal",
+        )
+        self.employee_proj = Employee.objects.create_user(
+            username="emp2",
+            password="pass",
+            first_name="Bob",
+            last_name="Brown",
+            project=self.project,
+            hire_date=date(2024, 1, 1),
+            employment_type="permanent",
+            visa_type="personal",
+        )
+        self.day_one = date(2024, 5, 1)
+        self.day_two = date(2024, 5, 2)
+
+        AttDay.objects.create(
+            employee=self.employee_dept,
+            date=self.day_one,
+            work_min=480,
+            late_min=5,
+            ot_regular_min=60,
+            status="present",
+            locked=False,
+            anomalies={"missing_out_closed_at_next_in": 1},
+        )
+        AttDay.objects.create(
+            employee=self.employee_dept,
+            date=self.day_two,
+            status="absent",
+        )
+        AttDay.objects.create(
+            employee=self.employee_proj,
+            date=self.day_one,
+            work_min=420,
+            status="present",
+        )
+
+        AttPair.objects.create(
+            employee=self.employee_dept,
+            date=self.day_one,
+            in_event_id=101,
+            out_event_id=102,
+            in_ts=timezone.make_aware(datetime(2024, 5, 1, 8, 0)),
+            out_ts=timezone.make_aware(datetime(2024, 5, 1, 16, 0)),
+            duration_min=480,
+        )
+
+        AttAdjustment.objects.create(
+            employee=self.employee_dept,
+            date=self.day_one,
+            delta_work_min=-15,
+            reason="Late arrival waiver",
+            created_by_id=self.admin.id,
+        )
+
+        AttDay.objects.filter(employee=self.employee_dept, date=self.day_one).update(locked=True)
+
+        self.client.force_authenticate(self.admin)
+
+    def _list_url(self):
+        return reverse(
+            "attendance-calendar-list", kwargs={"company_id": self.company.id}
+        )
+
+    def _detail_url(self, employee):
+        return reverse(
+            "attendance-calendar-detail",
+            kwargs={"company_id": self.company.id, "pk": employee.id},
+        )
+
+    def _lock_url(self):
+        return reverse(
+            "attendance-calendar-lock", kwargs={"company_id": self.company.id}
+        )
+
+    def _adjustments_url(self):
+        return reverse(
+            "attendance-calendar-adjustments",
+            kwargs={"company_id": self.company.id},
+        )
+
+    def test_calendar_list_returns_month_grid_with_summaries(self):
+        response = self.client.get(self._list_url(), {"month": "2024-05"})
+        assert response.status_code == 200
+        payload = response.json()
+        assert payload["month"] == "2024-05"
+        assert payload["days"][0] == "2024-05-01"
+        employees = {item["id"]: item for item in payload["employees"]}
+        assert set(employees.keys()) == {self.employee_dept.id, self.employee_proj.id}
+        dept_day = next(
+            row
+            for row in employees[self.employee_dept.id]["rows"]
+            if row["date"] == "2024-05-01"
+        )
+        assert dept_day["status"] == "present"
+        assert dept_day["locked"] is True
+        assert dept_day["locked_reason"]
+        assert dept_day["metrics"]["work_min"] == 480
+        assert dept_day["metrics"]["late_min"] == 5
+        assert dept_day["metrics"]["ot_regular_min"] == 60
+        assert dept_day["anomalies"] == {"missing_out_closed_at_next_in": 1}
+        summary = employees[self.employee_dept.id]["summary"]
+        assert summary["present"] == 1
+        assert summary["absent"] == 1
+        assert summary["locked_days"] == 1
+        assert summary["total_ot_min"] == 60
+
+    def test_calendar_list_includes_pairs_and_adjustments_when_requested(self):
+        response = self.client.get(
+            self._list_url(),
+            {
+                "month": "2024-05",
+                "include_pairs": "true",
+                "include_adjustments": "true",
+                "include_anomalies": "false",
+            },
+        )
+        assert response.status_code == 200
+        payload = response.json()
+        employees = {item["id"]: item for item in payload["employees"]}
+        row = next(
+            r
+            for r in employees[self.employee_dept.id]["rows"]
+            if r["date"] == "2024-05-01"
+        )
+        assert "pairs" in row and len(row["pairs"]) == 1
+        assert "adjustments" in row and len(row["adjustments"]) == 1
+        assert "anomalies" not in row
+
+    def test_calendar_list_search_filters_employees(self):
+        response = self.client.get(
+            self._list_url(),
+            {
+                "month": "2024-05",
+                "search": "Alice",
+            },
+        )
+        assert response.status_code == 200
+        payload = response.json()
+        ids = [emp["id"] for emp in payload["employees"]]
+        assert ids == [self.employee_dept.id]
+
+        response = self.client.get(
+            self._list_url(),
+            {
+                "month": "2024-05",
+                "search": "alice ops",
+            },
+        )
+        assert response.status_code == 200
+        payload = response.json()
+        ids = [emp["id"] for emp in payload["employees"]]
+        assert ids == [self.employee_dept.id]
+
+        response = self.client.get(
+            self._list_url(),
+            {
+                "month": "2024-05",
+                "search": "Site",
+            },
+        )
+        assert response.status_code == 200
+        payload = response.json()
+        ids = [emp["id"] for emp in payload["employees"]]
+        assert ids == [self.employee_proj.id]
+
+    def test_calendar_stats_only_returns_empty_rows(self):
+        response = self.client.get(
+            self._list_url(),
+            {
+                "month": "2024-05",
+                "stats_only": "true",
+            },
+        )
+        assert response.status_code == 200
+        payload = response.json()
+        assert all(emp["rows"] == [] for emp in payload["employees"])
+        employees = {item["id"]: item for item in payload["employees"]}
+        assert employees[self.employee_dept.id]["summary"]["present"] == 1
+
+    def test_calendar_detail_focuses_on_single_employee(self):
+        response = self.client.get(
+            self._detail_url(self.employee_dept),
+            {"month": "2024-05", "include_pairs": "true"},
+        )
+        assert response.status_code == 200
+        payload = response.json()
+        assert len(payload["employees"]) == 1
+        assert payload["employees"][0]["id"] == self.employee_dept.id
+
+    def test_calendar_lock_action_updates_days(self):
+        day = AttDay.objects.get(employee=self.employee_proj, date=self.day_one)
+        assert day.locked is False
+        response = self.client.post(
+            self._lock_url(),
+            {
+                "start": "2024-05-01",
+                "end": "2024-05-02",
+                "employee_ids": [self.employee_proj.id],
+                "locked": True,
+            },
+            format="json",
+        )
+        assert response.status_code == 200
+        assert response.json()["updated"] == 1
+        day.refresh_from_db()
+        assert day.locked is True
+
+    def test_calendar_adjustments_action_creates_record(self):
+        response = self.client.post(
+            self._adjustments_url(),
+            {
+                "employee": self.employee_proj.id,
+                "date": "2024-05-01",
+                "delta_work_min": 15,
+                "reason": "Manual correction",
+            },
+            format="json",
+        )
+        assert response.status_code == 201
+        created = AttAdjustment.objects.filter(employee=self.employee_proj).latest("id")
+        assert created.delta_work_min == 15
+        assert created.created_by_id == self.admin.id

--- a/attendance/urls.py
+++ b/attendance/urls.py
@@ -1,7 +1,12 @@
 from django.urls import path, include
 from rest_framework.routers import DefaultRouter
 
-from .views import AttDayViewSet, AttPairViewSet, AttAdjustmentViewSet
+from .views import (
+    AttDayViewSet,
+    AttPairViewSet,
+    AttAdjustmentViewSet,
+    AttendanceCalendarViewSet,
+)
 
 router = DefaultRouter()
 router.register(r"companies/(?P<company_id>\d+)/att-days", AttDayViewSet, basename="att-day")
@@ -10,6 +15,11 @@ router.register(
     r"companies/(?P<company_id>\d+)/att-adjustments",
     AttAdjustmentViewSet,
     basename="att-adjustment",
+)
+router.register(
+    r"companies/(?P<company_id>\d+)/attendance-calendar",
+    AttendanceCalendarViewSet,
+    basename="attendance-calendar",
 )
 
 urlpatterns = [path("", include(router.urls))]

--- a/attendance/views.py
+++ b/attendance/views.py
@@ -1,12 +1,18 @@
-from datetime import timedelta, date
+import calendar
+from collections import Counter, defaultdict
+from datetime import date, timedelta
 
-from rest_framework import viewsets, status, serializers
+from rest_framework import serializers, status, viewsets
 from rest_framework.decorators import action
 from rest_framework.renderers import BaseRenderer
 from rest_framework.response import Response
+from rest_framework.pagination import CursorPagination
 from rest_framework.permissions import IsAdminUser
+from rest_framework.exceptions import NotFound
 from django_filters.rest_framework import DjangoFilterBackend
 from django.db import transaction
+from django.db.models import CharField, Q, Value
+from django.db.models.functions import Coalesce
 from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import (
     OpenApiExample,
@@ -44,6 +50,337 @@ from .tasks import (
 
 MAX_RANGE_DAYS = 31
 MAX_EMPLOYEES = 50
+CALENDAR_PAGE_SIZE = 200
+LOCKED_REASON = "Attendance day is locked; adjustments are disabled."
+
+
+class AttendanceCalendarMetricsDocSerializer(serializers.Serializer):
+    work_min = serializers.IntegerField(help_text="Computed work minutes for the day")
+    unpaid_break_min = serializers.IntegerField(help_text="Unpaid break minutes deducted")
+    paid_break_min = serializers.IntegerField(help_text="Paid break minutes")
+    late_min = serializers.IntegerField(help_text="Minutes late relative to shift start")
+    early_leave_min = serializers.IntegerField(help_text="Minutes left before scheduled end")
+    ot_regular_min = serializers.IntegerField(help_text="Regular overtime minutes")
+    ot_night_min = serializers.IntegerField(help_text="Night overtime minutes")
+    ot_holiday_min = serializers.IntegerField(help_text="Holiday overtime minutes")
+    on_leave = serializers.BooleanField(help_text="True when the employee was on leave")
+    leave_portion = serializers.FloatField(help_text="Portion of the day covered by leave")
+    is_holiday = serializers.BooleanField(help_text="Day is marked as a holiday")
+    is_rest_day = serializers.BooleanField(help_text="Day is marked as a rest day")
+    pairs_count = serializers.IntegerField(help_text="Number of raw IN/OUT pairs recorded")
+    punches_used = serializers.IntegerField(help_text="Punch events contributing to computation")
+
+
+class AttendanceCalendarRowDocSerializer(serializers.Serializer):
+    date = serializers.DateField(format="iso-8601", help_text="Day within the requested month")
+    status = serializers.CharField(
+        allow_null=True,
+        help_text="Canonical attendance status (present, absent, leave, rest, holiday, partial)",
+    )
+    locked = serializers.BooleanField(help_text="Whether the day is locked for changes")
+    locked_reason = serializers.CharField(
+        allow_null=True,
+        help_text="Message explaining why adjustments are blocked when locked",
+    )
+    metrics = AttendanceCalendarMetricsDocSerializer()
+    anomalies = serializers.DictField(
+        child=serializers.IntegerField(),
+        required=False,
+        help_text="Counts keyed by canonical anomaly name",
+    )
+    pairs = AttPairSerializer(many=True, required=False, read_only=True)
+    adjustments = AttAdjustmentSerializer(many=True, required=False, read_only=True)
+
+
+class AttendanceCalendarSummaryDocSerializer(serializers.Serializer):
+    present = serializers.IntegerField(help_text="Number of present days in the month")
+    absent = serializers.IntegerField(help_text="Number of absent days in the month")
+    leave = serializers.IntegerField(help_text="Number of leave days in the month")
+    holiday = serializers.IntegerField(help_text="Number of holiday days in the month")
+    rest = serializers.IntegerField(help_text="Number of rest days in the month")
+    partial = serializers.IntegerField(help_text="Number of partial/exception days in the month")
+    locked_days = serializers.IntegerField(help_text="Count of days locked for changes")
+    total_ot_min = serializers.IntegerField(help_text="Total overtime minutes in the month")
+
+
+class AttendanceCalendarEmployeeMetadataDocSerializer(serializers.Serializer):
+    department = serializers.CharField(allow_null=True, required=False)
+    project = serializers.CharField(allow_null=True, required=False)
+    branch = serializers.CharField(allow_null=True, required=False)
+    code = serializers.CharField(help_text="Employee code/username")
+
+
+class AttendanceCalendarEmployeeDocSerializer(serializers.Serializer):
+    id = serializers.IntegerField()
+    display = serializers.CharField(help_text="Display name shown to the user")
+    metadata = AttendanceCalendarEmployeeMetadataDocSerializer()
+    rows = AttendanceCalendarRowDocSerializer(many=True, required=False)
+    summary = AttendanceCalendarSummaryDocSerializer()
+
+
+class AttendanceCalendarResponseDocSerializer(serializers.Serializer):
+    month = serializers.CharField(help_text="Requested month in YYYY-MM format")
+    days = serializers.ListField(
+        child=serializers.DateField(format="iso-8601"),
+        help_text="Ordered list of days that frame the calendar grid",
+    )
+    employees = AttendanceCalendarEmployeeDocSerializer(many=True)
+    next = serializers.CharField(
+        allow_null=True,
+        required=False,
+        help_text="Cursor to fetch the next page of employees when paginated",
+    )
+    previous = serializers.CharField(
+        allow_null=True,
+        required=False,
+        help_text="Cursor to fetch the previous page of employees",
+    )
+
+ATTENDANCE_CALENDAR_QUERY_PARAMS = [
+    OpenApiParameter(
+        "month",
+        OpenApiTypes.STR,
+        OpenApiParameter.QUERY,
+        required=True,
+        description=(
+            "Target month in YYYY-MM format. The API expands this to the first and last day "
+            "of the month to guarantee a 28–31 day window."
+        ),
+        examples=[OpenApiExample("May 2024", value="2024-05")],
+    ),
+    OpenApiParameter(
+        "include_pairs",
+        OpenApiTypes.BOOL,
+        OpenApiParameter.QUERY,
+        description="When true, embed AttPair records for each populated day",
+        examples=[OpenApiExample("Include pairs", value="true")],
+    ),
+    OpenApiParameter(
+        "include_adjustments",
+        OpenApiTypes.BOOL,
+        OpenApiParameter.QUERY,
+        description="When true, embed AttAdjustment records that land on the day",
+        examples=[OpenApiExample("Include adjustments", value="true")],
+    ),
+    OpenApiParameter(
+        "include_anomalies",
+        OpenApiTypes.BOOL,
+        OpenApiParameter.QUERY,
+        description="Toggle anomaly payloads on day rows. Defaults to true.",
+        examples=[OpenApiExample("Omit anomalies", value="false")],
+    ),
+    OpenApiParameter(
+        "stats_only",
+        OpenApiTypes.BOOL,
+        OpenApiParameter.QUERY,
+        description="Return only monthly summaries without the per-day grid",
+        examples=[OpenApiExample("Stats only", value="true")],
+    ),
+    OpenApiParameter(
+        "status",
+        OpenApiTypes.STR,
+        OpenApiParameter.QUERY,
+        description=(
+            "Comma separated list of AttDay.status values to include (e.g. present,absent,leave). "
+            "Only matching days appear in the grid and summary counts."
+        ),
+    ),
+    OpenApiParameter(
+        "locked",
+        OpenApiTypes.BOOL,
+        OpenApiParameter.QUERY,
+        description="Filter days by lock state before aggregation",
+    ),
+    OpenApiParameter(
+        "employee",
+        OpenApiTypes.STR,
+        OpenApiParameter.QUERY,
+        description=(
+            "Restrict the calendar to specific employees. Accepts repeated parameters or a comma "
+            "separated list of employee IDs."
+        ),
+    ),
+    OpenApiParameter(
+        "branch",
+        OpenApiTypes.STR,
+        OpenApiParameter.QUERY,
+        description=(
+            "Restrict employees by branch via their department or project relationship. Accepts "
+            "repeated parameters or a comma separated list of branch IDs."
+        ),
+    ),
+    OpenApiParameter(
+        "department",
+        OpenApiTypes.STR,
+        OpenApiParameter.QUERY,
+        description="Restrict employees by department IDs (repeated or comma separated)",
+    ),
+    OpenApiParameter(
+        "project",
+        OpenApiTypes.STR,
+        OpenApiParameter.QUERY,
+        description="Restrict employees by project IDs (repeated or comma separated)",
+    ),
+    OpenApiParameter(
+        "search",
+        OpenApiTypes.STR,
+        OpenApiParameter.QUERY,
+        description=(
+            "Case-insensitive text search over employee first name, last name, username, email, "
+            "department name, project name, and related branch names. All terms supplied must match."
+        ),
+        examples=[OpenApiExample("Find Alice", value="alice ops")],
+    ),
+    OpenApiParameter(
+        "sort",
+        OpenApiTypes.STR,
+        OpenApiParameter.QUERY,
+        description=(
+            "Comma separated list of fields to order employees by. Supports name, code, department, "
+            "project, first_name, last_name, and id. Prefix with '-' for descending order."
+        ),
+        examples=[OpenApiExample("Department then name", value="department,-name")],
+    ),
+]
+
+ATTENDANCE_CALENDAR_EXAMPLE = OpenApiExample(
+    "Calendar grid",
+    value={
+        "month": "2024-05",
+        "days": ["2024-05-01", "2024-05-02", "2024-05-03"],
+        "employees": [
+            {
+                "id": 17,
+                "display": "Maria Gomez",
+                "metadata": {
+                    "department": "Operations",
+                    "project": "Project Falcon",
+                    "branch": "Dubai Marina",
+                    "code": "EMP-0017",
+                },
+                "rows": [
+                    {
+                        "date": "2024-05-01",
+                        "status": "present",
+                        "locked": True,
+                        "locked_reason": "Attendance day is locked; adjustments are disabled.",
+                        "metrics": {
+                            "work_min": 480,
+                            "unpaid_break_min": 0,
+                            "paid_break_min": 60,
+                            "late_min": 5,
+                            "early_leave_min": 0,
+                            "ot_regular_min": 45,
+                            "ot_night_min": 0,
+                            "ot_holiday_min": 0,
+                            "on_leave": False,
+                            "leave_portion": 0.0,
+                            "is_holiday": False,
+                            "is_rest_day": False,
+                            "pairs_count": 2,
+                            "punches_used": 4,
+                        },
+                        "anomalies": {"missing_out_closed_at_next_in": 1},
+                        "adjustments": [
+                            {
+                                "id": 901,
+                                "employee": 17,
+                                "date": "2024-05-01",
+                                "delta_work_min": -15,
+                                "reason": "Late arrival waiver",
+                                "created_by_id": 3,
+                                "created_at": "2024-05-02T06:00:00Z",
+                            }
+                        ],
+                        "pairs": [
+                            {
+                                "id": 3001,
+                                "employee": 17,
+                                "date": "2024-05-01",
+                                "in_event_id": 555,
+                                "out_event_id": 556,
+                                "in_ts": "2024-05-01T08:00:00+04:00",
+                                "out_ts": "2024-05-01T12:00:00+04:00",
+                                "duration_min": 240,
+                                "cross_midnight": False,
+                                "source": "auto",
+                                "anomaly": {},
+                            }
+                        ],
+                    }
+                ],
+                "summary": {
+                    "present": 18,
+                    "absent": 2,
+                    "leave": 1,
+                    "holiday": 1,
+                    "rest": 3,
+                    "partial": 0,
+                    "locked_days": 12,
+                    "total_ot_min": 480,
+                },
+            }
+        ],
+        "next": None,
+        "previous": None,
+    },
+    response_only=True,
+)
+
+
+class AttendanceCalendarPagination(CursorPagination):
+    page_size = CALENDAR_PAGE_SIZE
+    ordering = ("first_name", "last_name", "username", "id")
+
+    def get_ordering(self, request, queryset, view):  # pragma: no cover - simple delegation
+        if getattr(view, "cursor_ordering", None):
+            return tuple(view.cursor_ordering)
+        return super().get_ordering(request, queryset, view)
+
+
+def parse_month(value: str):
+    if not value:
+        raise serializers.ValidationError({"month": "Expected YYYY-MM query parameter"})
+    try:
+        year, month = value.split("-")
+        start = date(int(year), int(month), 1)
+    except (TypeError, ValueError):
+        raise serializers.ValidationError({"month": "Expected YYYY-MM format"})
+    days_in_month = calendar.monthrange(start.year, start.month)[1]
+    end = start.replace(day=days_in_month)
+    return start, end
+
+
+def parse_bool(value, *, default=False):
+    if value is None:
+        return default
+    if isinstance(value, bool):
+        return value
+    value = value.lower()
+    if value in {"1", "true", "yes", "on"}:
+        return True
+    if value in {"0", "false", "no", "off"}:
+        return False
+    raise serializers.ValidationError({"detail": f"Invalid boolean value '{value}'"})
+
+
+def parse_int_list(value):
+    if value is None:
+        return []
+    if isinstance(value, (list, tuple)):
+        items = value
+    else:
+        items = str(value).split(",")
+    result = []
+    for item in items:
+        item = str(item).strip()
+        if not item:
+            continue
+        try:
+            result.append(int(item))
+        except ValueError as exc:
+            raise serializers.ValidationError({"detail": f"Invalid integer '{item}'"}) from exc
+    return result
 
 
 class LateComersPDFRenderer(BaseRenderer):
@@ -406,6 +743,511 @@ class AttPairViewSet(viewsets.ModelViewSet):
 # attach filter documentation
 document_filters(AttDayViewSet)
 document_filters(AttPairViewSet)
+
+
+@extend_schema_view(
+    list=extend_schema(
+        summary="List attendance calendar rows",
+        description=(
+            "Aggregate AttDay outcomes, optional AttPair sessions, and AttAdjustment entries into "
+            "a month-oriented matrix optimised for calendar widgets. The endpoint enforces scope "
+            "permissions identical to the AttDay and AttPair APIs, supports cursor pagination "
+            "for large employee sets, and exposes optional expansions so clients can trade payload "
+            "size for detail."
+        ),
+        parameters=ATTENDANCE_CALENDAR_QUERY_PARAMS,
+        responses={
+            200: OpenApiResponse(
+                description="Monthly attendance grid with optional drill-down detail",
+                response=AttendanceCalendarResponseDocSerializer,
+            )
+        },
+        examples=[ATTENDANCE_CALENDAR_EXAMPLE],
+    ),
+    retrieve=extend_schema(
+        summary="Retrieve calendar rows for a single employee",
+        description=(
+            "Return the same calendar payload as the list view but scoped to the employee identified "
+            "by the path parameter. Supports the same query parameters (month, include_* flags, "
+            "status, locked, search, etc.) so UI drill-down panels can reuse list view requests."
+        ),
+        parameters=ATTENDANCE_CALENDAR_QUERY_PARAMS,
+        responses={
+            200: OpenApiResponse(
+                description="Single-employee attendance calendar response",
+                response=AttendanceCalendarResponseDocSerializer,
+            )
+        },
+        examples=[ATTENDANCE_CALENDAR_EXAMPLE],
+    ),
+)
+@extend_schema(
+    tags=["Attendance"],
+    description=(
+        "Monthly attendance calendar endpoint that aggregates computed AttDay summaries, raw "
+        "pairs, and manual adjustments for each employee in scope. Use the optional lock and "
+        "adjustment actions to manage period finalisation without leaving the calendar view."
+    ),
+)
+class AttendanceCalendarViewSet(viewsets.GenericViewSet):
+    """Expose a monthly attendance calendar grid combining days, pairs and adjustments."""
+
+    queryset = Employee.objects.all()
+    pagination_class = AttendanceCalendarPagination
+    filter_backends = []
+
+    def get_queryset(self):
+        qs = (
+            super()
+            .get_queryset()
+            .select_related(
+                "department__branch",
+                "project__branch",
+                "trade_license__company",
+            )
+        )
+        return scope_queryset(qs, self.request.user)
+
+    def _filter_employees(self, queryset, request, company_id):
+        queryset = queryset.filter(is_superuser=False)
+        if company_id:
+            queryset = queryset.filter(
+                Q(trade_license__company_id=company_id)
+                | Q(department__branch__company_id=company_id)
+                | Q(project__branch__company_id=company_id)
+            )
+
+        employee_ids = parse_int_list(request.query_params.getlist("employee"))
+        if employee_ids:
+            queryset = queryset.filter(id__in=employee_ids)
+
+        branch_ids = parse_int_list(request.query_params.getlist("branch"))
+        if branch_ids:
+            branch_filter = Q()
+            for branch_id in branch_ids:
+                branch_filter |= Q(department__branch_id=branch_id)
+                branch_filter |= Q(project__branch_id=branch_id)
+            queryset = queryset.filter(branch_filter)
+
+        department_ids = parse_int_list(request.query_params.getlist("department"))
+        if department_ids:
+            queryset = queryset.filter(department_id__in=department_ids)
+
+        project_ids = parse_int_list(request.query_params.getlist("project"))
+        if project_ids:
+            queryset = queryset.filter(project_id__in=project_ids)
+
+        search_value = request.query_params.get("search", "").strip()
+        if search_value:
+            terms = [term for term in search_value.split() if term]
+            for term in terms:
+                term_filter = (
+                    Q(first_name__icontains=term)
+                    | Q(last_name__icontains=term)
+                    | Q(username__icontains=term)
+                    | Q(email__icontains=term)
+                    | Q(department__name__icontains=term)
+                    | Q(project__name__icontains=term)
+                    | Q(department__branch__name__icontains=term)
+                    | Q(project__branch__name__icontains=term)
+                )
+                queryset = queryset.filter(term_filter)
+
+        return queryset.distinct()
+
+    def _apply_sorting(self, queryset, request):
+        sort_param = request.query_params.get("sort", "").strip()
+        annotations = {}
+        ordering = []
+
+        field_map = {
+            "name": ["first_name", "last_name", "username"],
+            "first_name": ["first_name"],
+            "last_name": ["last_name"],
+            "code": ["username"],
+            "department": ["department_name"],
+            "project": ["project_name"],
+            "id": ["id"],
+        }
+
+        def ensure_annotation(key):
+            if key == "department_name" and "department_name" not in annotations:
+                annotations["department_name"] = Coalesce(
+                    "department__name",
+                    Value(""),
+                    output_field=CharField(),
+                )
+            if key == "project_name" and "project_name" not in annotations:
+                annotations["project_name"] = Coalesce(
+                    "project__name",
+                    Value(""),
+                    output_field=CharField(),
+                )
+
+        if sort_param:
+            for raw in sort_param.split(","):
+                raw = raw.strip()
+                if not raw:
+                    continue
+                descending = raw.startswith("-")
+                key = raw[1:] if descending else raw
+                mapped = field_map.get(key)
+                if not mapped:
+                    continue
+                for field_name in mapped:
+                    ensure_annotation(field_name)
+                    clause = field_name
+                    if descending:
+                        clause = f"-{clause}"
+                    ordering.append(clause)
+
+        if not ordering:
+            ordering = ["first_name", "last_name", "username"]
+
+        if not any(field.lstrip("-") == "id" for field in ordering):
+            ordering.append("id")
+
+        if annotations:
+            queryset = queryset.annotate(**annotations)
+
+        self.cursor_ordering = ordering
+        return queryset
+
+    def _build_calendar_response(
+        self,
+        employees,
+        start,
+        end,
+        *,
+        include_pairs,
+        include_adjustments,
+        include_anomalies,
+        stats_only,
+        status_filters,
+        locked_filter,
+    ):
+        days = [start + timedelta(days=offset) for offset in range((end - start).days + 1)]
+        employee_ids = [employee.id for employee in employees]
+        request = self.request
+        context = self.get_serializer_context()
+
+        day_map = defaultdict(dict)
+        if employee_ids:
+            day_qs = (
+                AttDay.objects.filter(employee_id__in=employee_ids, date__range=(start, end))
+                .select_related("shift", "roster")
+            )
+            day_qs = scope_queryset(day_qs, request.user)
+            if status_filters:
+                day_qs = day_qs.filter(status__in=status_filters)
+            if locked_filter is not None:
+                day_qs = day_qs.filter(locked=locked_filter)
+            for day in day_qs:
+                day_map[day.employee_id][day.date] = day
+
+        valid_keys = {(emp_id, day) for emp_id, entries in day_map.items() for day in entries.keys()}
+
+        pairs_data = {}
+        if include_pairs and not stats_only and valid_keys:
+            pair_qs = AttPair.objects.filter(
+                employee_id__in=employee_ids, date__range=(start, end)
+            ).order_by("in_ts")
+            pair_qs = scope_queryset(pair_qs, request.user)
+            grouped_pairs = defaultdict(list)
+            valid_dates = {key[1] for key in valid_keys}
+            pair_qs = pair_qs.filter(date__in=valid_dates)
+            for pair in pair_qs:
+                key = (pair.employee_id, pair.date)
+                if key in valid_keys:
+                    grouped_pairs[key].append(pair)
+            for key, records in grouped_pairs.items():
+                pairs_data[key] = AttPairSerializer(records, many=True, context=context).data
+
+        adjustments_data = {}
+        if include_adjustments and not stats_only and valid_keys:
+            adjustment_qs = AttAdjustment.objects.filter(
+                employee_id__in=employee_ids, date__range=(start, end)
+            ).order_by("created_at")
+            adjustment_qs = scope_queryset(adjustment_qs, request.user)
+            grouped_adjustments = defaultdict(list)
+            valid_dates = {key[1] for key in valid_keys}
+            adjustment_qs = adjustment_qs.filter(date__in=valid_dates)
+            for adjustment in adjustment_qs:
+                key = (adjustment.employee_id, adjustment.date)
+                if key in valid_keys:
+                    grouped_adjustments[key].append(adjustment)
+            for key, records in grouped_adjustments.items():
+                adjustments_data[key] = AttAdjustmentSerializer(
+                    records, many=True, context=context
+                ).data
+
+        employees_payload = []
+        for employee in employees:
+            employee_days = day_map.get(employee.id, {})
+            summary_counts = Counter()
+            locked_days = 0
+            total_ot = 0
+            rows = []
+
+            for current_day in days:
+                day = employee_days.get(current_day)
+                if day:
+                    summary_counts[day.status] += 1
+                    if day.locked:
+                        locked_days += 1
+                    total_ot += day.ot_regular_min + day.ot_night_min + day.ot_holiday_min
+                if stats_only:
+                    continue
+
+                key = (employee.id, current_day)
+                row = {
+                    "date": current_day.isoformat(),
+                    "status": day.status if day else None,
+                    "locked": bool(day.locked) if day else False,
+                    "locked_reason": LOCKED_REASON if day and day.locked else None,
+                    "metrics": {
+                        "work_min": day.work_min if day else 0,
+                        "unpaid_break_min": day.unpaid_break_min if day else 0,
+                        "paid_break_min": day.paid_break_min if day else 0,
+                        "late_min": day.late_min if day else 0,
+                        "early_leave_min": day.early_leave_min if day else 0,
+                        "ot_regular_min": day.ot_regular_min if day else 0,
+                        "ot_night_min": day.ot_night_min if day else 0,
+                        "ot_holiday_min": day.ot_holiday_min if day else 0,
+                        "on_leave": day.on_leave if day else False,
+                        "leave_portion": float(day.leave_portion) if day else 0.0,
+                        "is_holiday": day.is_holiday if day else False,
+                        "is_rest_day": day.is_rest_day if day else False,
+                        "pairs_count": day.pairs_count if day else 0,
+                        "punches_used": day.punches_used if day else 0,
+                    },
+                }
+                if include_anomalies:
+                    row["anomalies"] = day.anomalies if day else {}
+                if include_pairs:
+                    row["pairs"] = pairs_data.get(key, [])
+                if include_adjustments:
+                    row["adjustments"] = adjustments_data.get(key, [])
+                rows.append(row)
+
+            summary = {
+                "present": summary_counts.get("present", 0),
+                "absent": summary_counts.get("absent", 0),
+                "leave": summary_counts.get("leave", 0),
+                "holiday": summary_counts.get("holiday", 0),
+                "rest": summary_counts.get("rest", 0),
+                "partial": summary_counts.get("partial", 0),
+                "locked_days": locked_days,
+                "total_ot_min": total_ot,
+            }
+
+            branch = None
+            if employee.department and employee.department.branch:
+                branch = employee.department.branch
+            elif employee.project and employee.project.branch:
+                branch = employee.project.branch
+
+            employees_payload.append(
+                {
+                    "id": employee.id,
+                    "display": employee.get_full_name().strip() or employee.username,
+                    "metadata": {
+                        "department": employee.department.name if employee.department else None,
+                        "project": employee.project.name if employee.project else None,
+                        "branch": branch.name if branch else None,
+                        "code": employee.username,
+                    },
+                    "rows": [] if stats_only else rows,
+                    "summary": summary,
+                }
+            )
+
+        return {
+            "month": start.strftime("%Y-%m"),
+            "days": [day.isoformat() for day in days],
+            "employees": employees_payload,
+        }
+
+    def list(self, request, company_id=None):
+        start, end = parse_month(request.query_params.get("month"))
+        include_pairs = parse_bool(request.query_params.get("include_pairs"), default=False)
+        include_adjustments = parse_bool(
+            request.query_params.get("include_adjustments"), default=False
+        )
+        include_anomalies = parse_bool(
+            request.query_params.get("include_anomalies"), default=True
+        )
+        stats_only = parse_bool(request.query_params.get("stats_only"), default=False)
+
+        status_param = request.query_params.get("status")
+        status_filters = (
+            [value.strip() for value in status_param.split(",") if value.strip()]
+            if status_param
+            else []
+        )
+        locked_filter = None
+        if "locked" in request.query_params:
+            locked_filter = parse_bool(request.query_params.get("locked"))
+
+        queryset = self._filter_employees(self.get_queryset(), request, company_id)
+        queryset = self._apply_sorting(queryset, request)
+
+        page = self.paginate_queryset(queryset)
+        employees = list(page if page is not None else queryset[:CALENDAR_PAGE_SIZE])
+        if page is None and len(employees) > CALENDAR_PAGE_SIZE:
+            employees = employees[:CALENDAR_PAGE_SIZE]
+
+        payload = self._build_calendar_response(
+            employees,
+            start,
+            end,
+            include_pairs=include_pairs,
+            include_adjustments=include_adjustments,
+            include_anomalies=include_anomalies,
+            stats_only=stats_only,
+            status_filters=status_filters,
+            locked_filter=locked_filter,
+        )
+
+        if getattr(self, "paginator", None) and getattr(self.paginator, "page", None) is not None:
+            payload["next"] = self.paginator.get_next_link()
+            payload["previous"] = self.paginator.get_previous_link()
+        return Response(payload)
+
+    def retrieve(self, request, pk=None, company_id=None):
+        start, end = parse_month(request.query_params.get("month"))
+        include_pairs = parse_bool(request.query_params.get("include_pairs"), default=False)
+        include_adjustments = parse_bool(
+            request.query_params.get("include_adjustments"), default=False
+        )
+        include_anomalies = parse_bool(
+            request.query_params.get("include_anomalies"), default=True
+        )
+        stats_only = parse_bool(request.query_params.get("stats_only"), default=False)
+
+        status_param = request.query_params.get("status")
+        status_filters = (
+            [value.strip() for value in status_param.split(",") if value.strip()]
+            if status_param
+            else []
+        )
+        locked_filter = None
+        if "locked" in request.query_params:
+            locked_filter = parse_bool(request.query_params.get("locked"))
+
+        queryset = self._filter_employees(self.get_queryset(), request, company_id)
+        queryset = self._apply_sorting(queryset, request)
+        employee = queryset.filter(pk=pk).first()
+        if not employee:
+            raise NotFound("Employee not found")
+
+        payload = self._build_calendar_response(
+            [employee],
+            start,
+            end,
+            include_pairs=include_pairs,
+            include_adjustments=include_adjustments,
+            include_anomalies=include_anomalies,
+            stats_only=stats_only,
+            status_filters=status_filters,
+            locked_filter=locked_filter,
+        )
+        return Response(payload)
+
+    @action(detail=False, methods=["post"], url_path="lock")
+    @extend_schema(
+        summary="Lock or unlock computed attendance days",
+        request=LockDaysSerializer,
+        responses={
+            200: OpenApiResponse(
+                description="Number of AttDay rows updated",
+                response=inline_serializer(
+                    name="AttendanceCalendarLockResponse",
+                    fields={"updated": serializers.IntegerField()},
+                ),
+            )
+        },
+        examples=[
+            OpenApiExample(
+                "Lock May 2024",
+                value={
+                    "start": "2024-05-01",
+                    "end": "2024-05-31",
+                    "employee_ids": [42, 43],
+                    "locked": True,
+                },
+                request_only=True,
+            ),
+            OpenApiExample(
+                "Lock response",
+                value={"updated": 62},
+                response_only=True,
+            ),
+        ],
+    )
+    def lock(self, request, company_id=None):
+        params = LockDaysSerializer(data=request.data or {})
+        params.is_valid(raise_exception=True)
+        data = params.validated_data
+        start, end = data["start"], data["end"]
+        employee_ids = data.get("employee_ids", [])
+        queryset = AttDay.objects.filter(date__range=(start, end))
+        if company_id:
+            queryset = queryset.filter(
+                Q(employee__trade_license__company_id=company_id)
+                | Q(employee__department__branch__company_id=company_id)
+                | Q(employee__project__branch__company_id=company_id)
+            )
+        if employee_ids:
+            queryset = queryset.filter(employee_id__in=employee_ids)
+        queryset = scope_queryset(queryset, request.user)
+        with transaction.atomic():
+            updated = queryset.update(locked=data.get("locked", True))
+        return Response({"updated": updated})
+
+    @action(detail=False, methods=["post"], url_path="adjustments")
+    @extend_schema(
+        summary="Proxy to create a manual attendance adjustment",
+        request=AttAdjustmentSerializer,
+        responses={
+            201: OpenApiResponse(
+                description="Created adjustment",
+                response=AttAdjustmentSerializer,
+            )
+        },
+        examples=[
+            OpenApiExample(
+                "Create adjustment",
+                value={
+                    "employee": 42,
+                    "date": "2024-05-01",
+                    "delta_work_min": -15,
+                    "override_status": None,
+                    "reason": "Late arrival waiver",
+                },
+                request_only=True,
+            ),
+        ],
+    )
+    def adjustments(self, request, company_id=None):
+        serializer = AttAdjustmentSerializer(data=request.data, context=self.get_serializer_context())
+        serializer.is_valid(raise_exception=True)
+        employee = serializer.validated_data["employee"]
+        scoped_employee = scope_queryset(Employee.objects.filter(pk=employee.pk), request.user)
+        if company_id:
+            scoped_employee = scoped_employee.filter(
+                Q(trade_license__company_id=company_id)
+                | Q(department__branch__company_id=company_id)
+                | Q(project__branch__company_id=company_id)
+            )
+        if not scoped_employee.exists():
+            raise serializers.ValidationError({"detail": "Employee outside allowed scope"})
+        adjustment = serializer.save(created_by_id=request.user.id)
+        output = AttAdjustmentSerializer(adjustment, context=self.get_serializer_context())
+        return Response(output.data, status=status.HTTP_201_CREATED)
+
+
+document_filters(AttendanceCalendarViewSet)
 
 
 @extend_schema_view(


### PR DESCRIPTION
## Summary
- add an admin-side attendance calendar view that reuses the API helpers, supports optional detail toggles, and hooks into the existing object tools
- provide a dedicated calendar template and stylesheet so the grid renders with employee summaries, filters, and status styling
- cover the new admin workflow with tests that exercise redirects and rendering for the calendar view

## Testing
- python manage.py test attendance.tests.test_attendance_calendar_viewset attendance.tests.test_attday_admin

------
https://chatgpt.com/codex/tasks/task_e_68ca919c7f08832dbbc09e239b5ea018