### PR TITLE
Add monthly attendance PDF report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+## Unreleased
+
+- Added a monthly attendance PDF report with branch grouping, glyph legend, API
+  endpoint, and Django admin entry point.

--- a/README.md
+++ b/README.md
@@ -57,9 +57,10 @@ comprehensive automated test suite.
   enrollment with Amazon Rekognition, and raw punch ingestion with geofence and
   scope validation. Raw events are stored for later summarization by the policy
   layer.
-* **Late comers reporting** – Generate PDF summaries of late arrivals via API or
-  the admin interface. See [docs/attendance_reports.md](docs/attendance_reports.md)
-  for usage and query parameters.
+* **Attendance reporting** – Generate PDF summaries for late arrivals and full
+  monthly attendance grids via the API or admin interface. See
+  [docs/attendance_reports.md](docs/attendance_reports.md) for usage and query
+  parameters.
 
 ### Attendance calendar API
 

--- a/attendance/admin.py
+++ b/attendance/admin.py
@@ -1,5 +1,6 @@
 from datetime import date, timedelta
 from urllib.parse import urlsplit
+from types import SimpleNamespace
 
 from django.contrib import admin, messages
 from django.utils.safestring import mark_safe
@@ -7,7 +8,7 @@ from django import forms
 from django.template.response import TemplateResponse
 from django.shortcuts import redirect
 from django.urls import path
-from django.http import HttpResponse
+from django.http import HttpResponse, QueryDict
 from django.utils import timezone
 
 from rest_framework import serializers
@@ -18,13 +19,20 @@ from pagasys.models import Branch, Department, Employee, Project, ShiftTemplate
 from pagasys.utils import scope_queryset
 from .models import AttDay, AttPair, AttAdjustment, LeaveRequest, LeaveDay
 from .tasks import compute_employee_day_task, recompute_range_task
-from .reports import get_late_comers, group_late_comers, render_late_comers_pdf
+from .reports import (
+    get_late_comers,
+    group_late_comers,
+    render_late_comers_pdf,
+    render_monthly_attendance_pdf,
+)
 from .views import (
     AttendanceCalendarViewSet,
     CALENDAR_PAGE_SIZE,
     parse_bool,
     parse_month,
 )
+from .services import build_monthly_calendar
+from .forms import MonthlyAttendanceReportForm
 
 
 class AttAdjustmentForm(forms.ModelForm):
@@ -206,17 +214,19 @@ class AttDayAdmin(ScopedAdminMixin, admin.ModelAdmin):
         if not using_pagination and len(employees) > CALENDAR_PAGE_SIZE:
             employees = employees[:CALENDAR_PAGE_SIZE]
 
-        payload = viewset._build_calendar_response(
+        calendar_result = build_monthly_calendar(
             employees,
-            start,
-            end,
+            (start, end),
+            user=request.user,
             include_pairs=include_pairs,
             include_adjustments=include_adjustments,
             include_anomalies=include_anomalies,
             stats_only=stats_only,
             status_filters=status_filters,
             locked_filter=locked_filter,
+            serializer_context=viewset.get_serializer_context(),
         )
+        payload = calendar_result["payload"]
 
         paginator = getattr(viewset, "paginator", None)
         next_link = previous_link = None
@@ -522,11 +532,19 @@ class AttDayAdmin(ScopedAdminMixin, admin.ModelAdmin):
                 self.admin_site.admin_view(self.late_comers_report_view),
                 name="attendance_attday_late_comers_report",
             ),
+            path(
+                "monthly-attendance-report/",
+                self.admin_site.admin_view(self.monthly_attendance_report_view),
+                name="attendance_attday_monthly_report",
+            ),
         ]
         return custom + urls
 
     def late_comers_report_view(self, request):  # pragma: no cover - admin view
         return self.late_comers_report(request)
+
+    def monthly_attendance_report_view(self, request):  # pragma: no cover - admin view
+        return self.monthly_attendance_report(request)
 
     def late_comers_report(self, request):  # pragma: no cover - admin view
         if request.method == "POST":
@@ -551,6 +569,86 @@ class AttDayAdmin(ScopedAdminMixin, admin.ModelAdmin):
             form = self.LateComersReportForm(request=request)
         context = {"form": form, "title": "Late comers report"}
         return TemplateResponse(request, "admin/late_comers_report.html", context)
+
+    def monthly_attendance_report(self, request):  # pragma: no cover - admin view
+        form_kwargs = {"request": request}
+        status_choices = dict(AttDay._meta.get_field("status").choices)
+        if request.method == "POST":
+            form = MonthlyAttendanceReportForm(request.POST, **form_kwargs)
+            if form.is_valid():
+                month_value = form.cleaned_data["month"]
+                start, end = parse_month(month_value)
+
+                viewset = AttendanceCalendarViewSet()
+                drf_request = Request(request)
+                drf_request.user = request.user
+                viewset.request = drf_request
+                viewset.args = []
+                viewset.kwargs = {}
+                viewset.action = "monthly_report"
+                viewset.format_kwarg = None
+
+                params = QueryDict(mutable=True)
+                branch = form.cleaned_data.get("branch")
+                department = form.cleaned_data.get("department")
+                project = form.cleaned_data.get("project")
+                statuses = form.cleaned_statuses()
+                locked_value = form.cleaned_locked_value()
+
+                if branch:
+                    params.setlist("branch", [str(branch.pk)])
+                if department:
+                    params.setlist("department", [str(department.pk)])
+                if project:
+                    params.setlist("project", [str(project.pk)])
+                if statuses:
+                    params["status"] = ",".join(statuses)
+                if locked_value is not None:
+                    params["locked"] = "true" if locked_value else "false"
+
+                filter_request = SimpleNamespace(query_params=params)
+                queryset = viewset._filter_employees(viewset.get_queryset(), filter_request, None)
+                queryset = viewset._apply_sorting(queryset, filter_request)
+                employees = list(queryset)
+
+                calendar_result = build_monthly_calendar(
+                    employees,
+                    (start, end),
+                    user=request.user,
+                    include_pairs=False,
+                    include_adjustments=False,
+                    include_anomalies=False,
+                    stats_only=False,
+                    status_filters=statuses,
+                    locked_filter=locked_value,
+                    serializer_context=viewset.get_serializer_context(),
+                )
+
+                filters_summary = {
+                    "branch": [branch.name] if branch else [],
+                    "department": [department.name] if department else [],
+                    "project": [project.name] if project else [],
+                    "status": [status_choices.get(code, code) for code in statuses],
+                    "locked": (
+                        "Locked only" if locked_value is True else "Unlocked only" if locked_value is False else ""
+                    ),
+                }
+
+                pdf_context = {
+                    "request": request,
+                    "filters": filters_summary,
+                    "title": "Monthly attendance report",
+                }
+                pdf = render_monthly_attendance_pdf(calendar_result["report"], pdf_context)
+                filename = f"monthly_attendance_{month_value}.pdf"
+                response = HttpResponse(pdf, content_type="application/pdf")
+                response["Content-Disposition"] = f"attachment; filename={filename}"
+                return response
+        else:
+            form = MonthlyAttendanceReportForm(**form_kwargs)
+
+        context = {"form": form, "title": "Monthly attendance report"}
+        return TemplateResponse(request, "admin/monthly_attendance_report.html", context)
 @admin.register(AttPair)
 class AttPairAdmin(ScopedAdminMixin, admin.ModelAdmin):
     """Review paired IN/OUT punch sessions."""

--- a/attendance/forms.py
+++ b/attendance/forms.py
@@ -1,0 +1,78 @@
+from django import forms
+from rest_framework import serializers
+
+from pagasys.models import Branch, Department, Project
+from pagasys.utils import scope_queryset
+
+from .models import AttDay
+from .views import parse_month
+
+
+class MonthlyAttendanceReportForm(forms.Form):
+    month = forms.CharField(
+        label="Month",
+        widget=forms.DateInput(attrs={"type": "month"}),
+        help_text="Select the month to summarise (YYYY-MM).",
+    )
+    branch = forms.ModelChoiceField(
+        queryset=Branch.objects.none(),
+        required=False,
+        empty_label="All branches",
+    )
+    department = forms.ModelChoiceField(
+        queryset=Department.objects.none(),
+        required=False,
+        empty_label="All departments",
+    )
+    project = forms.ModelChoiceField(
+        queryset=Project.objects.none(),
+        required=False,
+        empty_label="All projects",
+    )
+    status = forms.MultipleChoiceField(
+        required=False,
+        choices=AttDay._meta.get_field("status").choices,
+        widget=forms.SelectMultiple,
+        help_text="Optional: restrict the report to specific attendance statuses.",
+    )
+    locked = forms.ChoiceField(
+        required=False,
+        choices=[
+            ("", "All days"),
+            ("true", "Locked only"),
+            ("false", "Unlocked only"),
+        ],
+        help_text="Optional: limit the report to locked or unlocked days.",
+    )
+
+    def __init__(self, *args, request=None, **kwargs):
+        super().__init__(*args, **kwargs)
+        queryset_map = {
+            "branch": Branch,
+            "department": Department,
+            "project": Project,
+        }
+        for field_name, model in queryset_map.items():
+            qs = model.objects.all()
+            if request is not None:
+                qs = scope_queryset(qs, request.user)
+            self.fields[field_name].queryset = qs.order_by("name")
+
+    def clean_month(self):
+        value = self.cleaned_data.get("month")
+        try:
+            parse_month(value)
+        except serializers.ValidationError as exc:
+            raise forms.ValidationError(exc.detail.get("month", exc.detail)) from exc
+        return value
+
+    def cleaned_statuses(self):
+        return self.cleaned_data.get("status") or []
+
+    def cleaned_locked_value(self):
+        value = self.cleaned_data.get("locked")
+        if value == "true":
+            return True
+        if value == "false":
+            return False
+        return None

--- a/attendance/reports.py
+++ b/attendance/reports.py
@@ -143,9 +143,35 @@ def render_late_comers_pdf(
     return HTML(string=html, base_url=base_url).write_pdf(stylesheets=stylesheets)
 
 
+def render_monthly_attendance_pdf(report, context=None):
+    """Render the monthly attendance grid as a PDF document."""
+
+    context = context or {}
+    request = context.get("request")
+    logo_url = context.get("logo_url") or static("images/logo.png")
+    base_url = None
+    if request and hasattr(request, "build_absolute_uri"):
+        logo_url = request.build_absolute_uri(logo_url)
+        base_url = request.build_absolute_uri("/")
+
+    template_context = {
+        "report": report,
+        "title": context.get("title", "Monthly attendance report"),
+        "company": context.get("company"),
+        "filters": context.get("filters", {}),
+        "generated_at": context.get("generated_at", timezone.now()),
+        "logo_url": logo_url,
+    }
+    html = render_to_string("reports/monthly_attendance.html", template_context)
+    stylesheet_path = finders.find("attendance/css/reports.css")
+    stylesheets = [CSS(filename=stylesheet_path)] if stylesheet_path else None
+    return HTML(string=html, base_url=base_url).write_pdf(stylesheets=stylesheets)
+
+
 __all__ = [
     "get_late_comers",
     "group_late_comers",
     "render_late_comers_pdf",
+    "render_monthly_attendance_pdf",
 ]
 

--- a/attendance/services.py
+++ b/attendance/services.py
@@ -1,12 +1,16 @@
-from datetime import datetime, date, time
+import calendar
+from collections import Counter, defaultdict, OrderedDict
+from datetime import datetime, date, time, timedelta
 from zoneinfo import ZoneInfo
 
 from django.db import transaction
 from django.utils import timezone
 
 from capture.models import PunchEvent, PunchException
-from .models import AttPair, AttDay, LeaveDay
+from .models import AttPair, AttDay, LeaveDay, AttAdjustment
+from .serializers import AttPairSerializer, AttAdjustmentSerializer
 from pagasys.models import RosterEntry, ShiftRule
+from pagasys.utils import scope_queryset
 from .services_helpers import (
     _close_open_pairs_with_shift,
     _collect_pair_anomalies,
@@ -30,6 +34,86 @@ REJECTION_KEYS = {
     "geofence_rule_violation",
     "outside_scope",
 }
+
+
+LOCKED_DAY_REASON = "Attendance day is locked; adjustments are disabled."
+UNASSIGNED_BRANCH_LABEL = "Unassigned"
+
+MONTHLY_STATUS_LEGEND = OrderedDict(
+    [
+        (
+            "present",
+            {
+                "glyph": "P",
+                "css_class": "status-present",
+                "label": "Present",
+            },
+        ),
+        (
+            "absent",
+            {
+                "glyph": "A",
+                "css_class": "status-absent",
+                "label": "Absent / Leave",
+            },
+        ),
+        (
+            "rest",
+            {
+                "glyph": "R",
+                "css_class": "status-rest",
+                "label": "Rest / Holiday",
+            },
+        ),
+        (
+            "partial",
+            {
+                "glyph": "T",
+                "css_class": "status-partial",
+                "label": "Partial",
+            },
+        ),
+        (
+            "empty",
+            {
+                "glyph": "-",
+                "css_class": "status-empty",
+                "label": "No data",
+            },
+        ),
+    ]
+)
+
+STATUS_TO_LEGEND = {
+    "present": "present",
+    "absent": "absent",
+    "leave": "absent",
+    "rest": "rest",
+    "holiday": "rest",
+    "partial": "partial",
+}
+
+
+def _resolve_day_status(
+    *,
+    total_work: int,
+    sched_req: int,
+    on_leave: bool,
+    leave_portion: float,
+    is_hol: bool,
+    is_rest: bool,
+) -> str:
+    if on_leave and leave_portion >= 1:
+        return "leave"
+    if is_hol and total_work == 0:
+        return "holiday"
+    if is_rest and total_work == 0:
+        return "rest"
+    if sched_req > 0 and total_work >= sched_req:
+        return "present" if not on_leave else "partial"
+    if total_work > 0 or (on_leave and leave_portion > 0):
+        return "partial"
+    return "leave" if on_leave else "absent"
 
 
 def _eligible(ev: PunchEvent):
@@ -331,18 +415,14 @@ def compute_att_day(employee_id: int, day: date) -> int:
         ot_hol = _round_minutes(ot_hol, shift.rounding_min)
 
     total_work = work_min + ot_reg + ot_night + ot_hol
-    if on_leave and leave_portion >= 1:
-        status = "leave"
-    elif is_hol and total_work == 0:
-        status = "holiday"
-    elif is_rest and total_work == 0:
-        status = "rest"
-    elif sched_req > 0 and total_work >= sched_req:
-        status = "present" if not on_leave else "partial"
-    elif total_work > 0 or (on_leave and leave_portion > 0):
-        status = "partial"
-    else:
-        status = "leave" if on_leave else "absent"
+    status = _resolve_day_status(
+        total_work=total_work,
+        sched_req=sched_req,
+        on_leave=on_leave,
+        leave_portion=leave_portion,
+        is_hol=is_hol,
+        is_rest=is_rest,
+    )
 
     (
         work_min,
@@ -353,6 +433,7 @@ def compute_att_day(employee_id: int, day: date) -> int:
         ot_hol,
         status,
         anomalies_all,
+        override_applied,
     ) = apply_att_adjustments(
         employee_id,
         day,
@@ -365,6 +446,17 @@ def compute_att_day(employee_id: int, day: date) -> int:
         status,
         anomalies_all,
     )
+
+    if not override_applied:
+        total_work = work_min + ot_reg + ot_night + ot_hol
+        status = _resolve_day_status(
+            total_work=total_work,
+            sched_req=sched_req,
+            on_leave=on_leave,
+            leave_portion=leave_portion,
+            is_hol=is_hol,
+            is_rest=is_rest,
+        )
 
     for k, v in dict(
         shift_id=shift.id if shift else None,
@@ -389,3 +481,304 @@ def compute_att_day(employee_id: int, day: date) -> int:
         setattr(obj, k, v)
     obj.save()
     return 1
+
+
+def _resolve_month_range(month):
+    """Return the first and last day for a month representation."""
+
+    if isinstance(month, tuple) and len(month) == 2:
+        start, end = month
+        if not isinstance(start, date) or not isinstance(end, date):
+            raise ValueError("Month tuple must contain date objects")
+    elif isinstance(month, date):
+        start = month.replace(day=1)
+        days_in_month = calendar.monthrange(start.year, start.month)[1]
+        end = start.replace(day=days_in_month)
+    elif isinstance(month, str):
+        try:
+            year, month_value = month.split("-")
+            start = date(int(year), int(month_value), 1)
+        except (TypeError, ValueError) as exc:  # pragma: no cover - defensive guard
+            raise ValueError("Expected YYYY-MM formatted string") from exc
+        days_in_month = calendar.monthrange(start.year, start.month)[1]
+        end = start.replace(day=days_in_month)
+    else:  # pragma: no cover - defensive guard
+        raise ValueError("Unsupported month type")
+    if end < start:  # pragma: no cover - invalid ranges guarded upstream
+        raise ValueError("Month end must be on or after start")
+    return start, end
+
+
+def _legend_key_for_status(status: str | None) -> str:
+    if not status:
+        return "empty"
+    return STATUS_TO_LEGEND.get(status, "empty")
+
+
+def _cell_classnames(raw_status: str | None, legend_key: str, locked: bool) -> str:
+    classes = [MONTHLY_STATUS_LEGEND[legend_key]["css_class"]]
+    if raw_status and raw_status not in STATUS_TO_LEGEND:
+        classes.append(f"status-{raw_status}")
+    if locked:
+        classes.append("is-locked")
+    return " ".join(classes)
+
+
+def build_monthly_calendar(
+    employees,
+    month,
+    *,
+    user,
+    include_pairs=False,
+    include_adjustments=False,
+    include_anomalies=True,
+    stats_only=False,
+    status_filters=None,
+    locked_filter=None,
+    serializer_context=None,
+):
+    """Aggregate AttDay data into calendar payloads and PDF-friendly groups."""
+
+    status_filters = status_filters or []
+    serializer_context = serializer_context or {}
+    start, end = _resolve_month_range(month)
+    days = [start + timedelta(days=offset) for offset in range((end - start).days + 1)]
+
+    employees = list(employees)
+    employee_ids = [employee.id for employee in employees]
+
+    day_map = defaultdict(dict)
+    if employee_ids:
+        day_qs = (
+            AttDay.objects.filter(employee_id__in=employee_ids, date__range=(start, end))
+            .select_related("shift", "roster")
+            .order_by("employee_id", "date")
+        )
+        if user is not None:
+            day_qs = scope_queryset(day_qs, user)
+        if status_filters:
+            day_qs = day_qs.filter(status__in=status_filters)
+        if locked_filter is not None:
+            day_qs = day_qs.filter(locked=locked_filter)
+        for day in day_qs:
+            day_map[day.employee_id][day.date] = day
+
+    valid_keys = {
+        (emp_id, day_date)
+        for emp_id, entries in day_map.items()
+        for day_date in entries.keys()
+    }
+
+    pairs_data = {}
+    if include_pairs and not stats_only and valid_keys:
+        pair_qs = AttPair.objects.filter(
+            employee_id__in=employee_ids, date__range=(start, end)
+        ).order_by("in_ts")
+        if user is not None:
+            pair_qs = scope_queryset(pair_qs, user)
+        valid_dates = {key[1] for key in valid_keys}
+        pair_qs = pair_qs.filter(date__in=valid_dates)
+        grouped_pairs = defaultdict(list)
+        for pair in pair_qs:
+            key = (pair.employee_id, pair.date)
+            if key in valid_keys:
+                grouped_pairs[key].append(pair)
+        for key, records in grouped_pairs.items():
+            pairs_data[key] = AttPairSerializer(
+                records, many=True, context=serializer_context
+            ).data
+
+    adjustments_data = {}
+    if include_adjustments and not stats_only and valid_keys:
+        adjustment_qs = AttAdjustment.objects.filter(
+            employee_id__in=employee_ids, date__range=(start, end)
+        ).order_by("created_at")
+        if user is not None:
+            adjustment_qs = scope_queryset(adjustment_qs, user)
+        valid_dates = {key[1] for key in valid_keys}
+        adjustment_qs = adjustment_qs.filter(date__in=valid_dates)
+        grouped_adjustments = defaultdict(list)
+        for adjustment in adjustment_qs:
+            key = (adjustment.employee_id, adjustment.date)
+            if key in valid_keys:
+                grouped_adjustments[key].append(adjustment)
+        for key, records in grouped_adjustments.items():
+            adjustments_data[key] = AttAdjustmentSerializer(
+                records, many=True, context=serializer_context
+            ).data
+
+    payload_employees = []
+    branch_employee_map = defaultdict(list)
+    branch_totals = defaultdict(Counter)
+    overall_totals = Counter()
+    legend_keys = list(MONTHLY_STATUS_LEGEND.keys())
+    legend_entries = [
+        {"key": key, **MONTHLY_STATUS_LEGEND[key]} for key in legend_keys
+    ]
+
+    for employee in employees:
+        employee_days = day_map.get(employee.id, {})
+        summary_counts = Counter()
+        locked_days = 0
+        total_ot = 0
+        rows = []
+        report_rows = []
+        report_counts = Counter()
+
+        for current_day in days:
+            att_day = employee_days.get(current_day)
+            raw_status = att_day.status if att_day else None
+            legend_key = _legend_key_for_status(raw_status)
+            locked = bool(att_day.locked) if att_day else False
+
+            if att_day:
+                summary_counts[raw_status] += 1
+                if locked:
+                    locked_days += 1
+                total_ot += (
+                    att_day.ot_regular_min
+                    + att_day.ot_night_min
+                    + att_day.ot_holiday_min
+                )
+            report_counts[legend_key] += 1
+
+            if not stats_only:
+                key = (employee.id, current_day)
+                row = {
+                    "date": current_day.isoformat(),
+                    "status": raw_status,
+                    "locked": locked,
+                    "locked_reason": LOCKED_DAY_REASON if locked else None,
+                    "metrics": {
+                        "work_min": att_day.work_min if att_day else 0,
+                        "unpaid_break_min": att_day.unpaid_break_min if att_day else 0,
+                        "paid_break_min": att_day.paid_break_min if att_day else 0,
+                        "late_min": att_day.late_min if att_day else 0,
+                        "early_leave_min": att_day.early_leave_min if att_day else 0,
+                        "ot_regular_min": att_day.ot_regular_min if att_day else 0,
+                        "ot_night_min": att_day.ot_night_min if att_day else 0,
+                        "ot_holiday_min": att_day.ot_holiday_min if att_day else 0,
+                        "on_leave": att_day.on_leave if att_day else False,
+                        "leave_portion": float(att_day.leave_portion) if att_day else 0.0,
+                        "is_holiday": att_day.is_holiday if att_day else False,
+                        "is_rest_day": att_day.is_rest_day if att_day else False,
+                        "pairs_count": att_day.pairs_count if att_day else 0,
+                        "punches_used": att_day.punches_used if att_day else 0,
+                    },
+                }
+                if include_anomalies:
+                    row["anomalies"] = att_day.anomalies if att_day else {}
+                if include_pairs:
+                    row["pairs"] = pairs_data.get(key, [])
+                if include_adjustments:
+                    row["adjustments"] = adjustments_data.get(key, [])
+                rows.append(row)
+
+            report_rows.append(
+                {
+                    "date": current_day,
+                    "iso": current_day.isoformat(),
+                    "status": raw_status,
+                    "legend_key": legend_key,
+                    "glyph": MONTHLY_STATUS_LEGEND[legend_key]["glyph"],
+                    "css_class": _cell_classnames(raw_status, legend_key, locked),
+                    "locked": locked,
+                }
+            )
+
+        summary = {
+            "present": summary_counts.get("present", 0),
+            "absent": summary_counts.get("absent", 0),
+            "leave": summary_counts.get("leave", 0),
+            "holiday": summary_counts.get("holiday", 0),
+            "rest": summary_counts.get("rest", 0),
+            "partial": summary_counts.get("partial", 0),
+            "locked_days": locked_days,
+            "total_ot_min": total_ot,
+        }
+
+        branch = None
+        if employee.department and employee.department.branch:
+            branch = employee.department.branch
+        elif employee.project and employee.project.branch:
+            branch = employee.project.branch
+        branch_name = branch.name if branch else UNASSIGNED_BRANCH_LABEL
+
+        display_name = employee.get_full_name().strip() or employee.username
+        metadata = {
+            "department": employee.department.name if employee.department else None,
+            "project": employee.project.name if employee.project else None,
+            "branch": branch_name if branch_name else None,
+            "code": employee.username,
+        }
+
+        payload_employees.append(
+            {
+                "id": employee.id,
+                "display": display_name,
+                "metadata": metadata,
+                "rows": [] if stats_only else rows,
+                "summary": summary,
+            }
+        )
+
+        branch_employee_map[branch_name].append(
+            {
+                "id": employee.id,
+                "display": display_name,
+                "metadata": metadata,
+                "rows": report_rows,
+                "counts": {key: report_counts.get(key, 0) for key in legend_keys},
+            }
+        )
+        branch_totals[branch_name].update(report_counts)
+        overall_totals.update(report_counts)
+
+    branch_sections = OrderedDict()
+    for branch_name in sorted(branch_employee_map):
+        employees_for_branch = branch_employee_map[branch_name]
+        employees_for_branch.sort(key=lambda item: item["display"].casefold())
+        totals = branch_totals.get(branch_name, Counter())
+        branch_sections[branch_name] = {
+            "name": branch_name,
+            "employees": employees_for_branch,
+            "totals": {key: totals.get(key, 0) for key in legend_keys},
+            "legend_totals": [
+                {**entry, "count": totals.get(entry["key"], 0)}
+                for entry in legend_entries
+            ],
+            "employee_count": len(employees_for_branch),
+        }
+
+    payload = {
+        "month": start.strftime("%Y-%m"),
+        "days": [day.isoformat() for day in days],
+        "employees": payload_employees,
+    }
+
+    report_days = [
+        {
+            "date": day,
+            "iso": day.isoformat(),
+            "day": day.day,
+            "weekday": day.strftime("%a"),
+        }
+        for day in days
+    ]
+
+    report = {
+        "month": start.strftime("%Y-%m"),
+        "month_label": start.strftime("%B %Y"),
+        "days": report_days,
+        "branches": branch_sections,
+        "branch_list": list(branch_sections.values()),
+        "legend": legend_entries,
+        "totals": {key: overall_totals.get(key, 0) for key in legend_keys},
+        "legend_totals": [
+            {**entry, "count": overall_totals.get(entry["key"], 0)}
+            for entry in legend_entries
+        ],
+        "employee_count": len(payload_employees),
+    }
+
+    return {"payload": payload, "report": report}

--- a/attendance/services_helpers.py
+++ b/attendance/services_helpers.py
@@ -330,7 +330,17 @@ def apply_att_adjustments(
 
     adjustments = AttAdjustment.objects.filter(employee_id=employee_id, date=day)
     if not adjustments:
-        return work_min, unpaid_break, paid_break, ot_reg, ot_night, ot_hol, status, anomalies
+        return (
+            work_min,
+            unpaid_break,
+            paid_break,
+            ot_reg,
+            ot_night,
+            ot_hol,
+            status,
+            anomalies,
+            False,
+        )
 
     deltas = {
         "delta_work_min": 0,
@@ -341,6 +351,7 @@ def apply_att_adjustments(
         "delta_ot_holiday_min": 0,
     }
     override = None
+    override_applied = False
     for adj in adjustments:
         deltas["delta_work_min"] += adj.delta_work_min
         deltas["delta_unpaid_break_min"] += adj.delta_unpaid_break_min
@@ -359,6 +370,17 @@ def apply_att_adjustments(
     ot_hol += deltas["delta_ot_holiday_min"]
     if override:
         status = override
+        override_applied = True
     anomalies["manual_adjustments_applied"] = True
 
-    return work_min, unpaid_break, paid_break, ot_reg, ot_night, ot_hol, status, anomalies
+    return (
+        work_min,
+        unpaid_break,
+        paid_break,
+        ot_reg,
+        ot_night,
+        ot_hol,
+        status,
+        anomalies,
+        override_applied,
+    )

--- a/attendance/static/attendance/css/reports.css
+++ b/attendance/static/attendance/css/reports.css
@@ -11,6 +11,17 @@
   }
 }
 
+@page monthly-attendance {
+  size: A4 landscape;
+  margin: 18mm 14mm 20mm;
+  @top-center {
+    content: element(report-header);
+  }
+  @bottom-center {
+    content: element(report-footer);
+  }
+}
+
 body.report-body {
   font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
   font-size: 10.5pt;
@@ -18,6 +29,11 @@ body.report-body {
   color: #1f2933;
   background: #ffffff;
   margin: 0;
+}
+
+.monthly-attendance-report {
+  page: monthly-attendance;
+  font-size: 9.5pt;
 }
 
 p {
@@ -121,6 +137,262 @@ p {
 
 .report-footer .page-number::after {
   content: "Page " counter(page) " of " counter(pages);
+}
+
+.monthly-attendance-report main.report-content {
+  margin-top: 6mm;
+}
+
+.monthly-attendance-report .report-overview {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8mm;
+  align-items: flex-start;
+  margin-bottom: 10mm;
+}
+
+.monthly-attendance-report .report-summary-card {
+  min-width: 60mm;
+  padding: 4mm 5mm;
+  border: 1px solid #e2e8f0;
+  border-radius: 4px;
+  background: #f8fafc;
+}
+
+.monthly-attendance-report .report-summary-card h2 {
+  margin: 0 0 2mm;
+  font-size: 11pt;
+  font-weight: 600;
+  color: #0f172a;
+}
+
+.monthly-attendance-report .report-summary-list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  font-size: 9pt;
+}
+
+.monthly-attendance-report .report-summary-list li {
+  display: flex;
+  justify-content: space-between;
+  gap: 4mm;
+  padding: 1mm 0;
+  border-bottom: 1px dotted #cbd5f5;
+}
+
+.monthly-attendance-report .report-summary-list li:last-child {
+  border-bottom: none;
+}
+
+.monthly-attendance-report .filters-list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  font-size: 8.5pt;
+  color: #475569;
+}
+
+.monthly-attendance-report .filters-list li {
+  margin-bottom: 1.5mm;
+}
+
+.monthly-attendance-report .filters-list .label {
+  font-weight: 600;
+  color: #1e293b;
+  margin-right: 2mm;
+}
+
+.monthly-attendance-report .branch-section {
+  margin-bottom: 14mm;
+  page-break-inside: avoid;
+}
+
+.monthly-attendance-report .branch-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-end;
+  gap: 6mm;
+  margin-bottom: 4mm;
+  border-bottom: 1px solid #e2e8f0;
+  padding-bottom: 2mm;
+}
+
+.monthly-attendance-report .branch-title {
+  margin: 0;
+  font-size: 14pt;
+  font-weight: 600;
+  color: #0f172a;
+}
+
+.monthly-attendance-report .branch-subtitle {
+  margin: 0;
+  font-size: 9pt;
+  color: #475569;
+}
+
+.monthly-attendance-report .branch-totals {
+  display: flex;
+  gap: 5mm;
+  flex-wrap: wrap;
+  align-items: center;
+  font-size: 8.5pt;
+}
+
+.monthly-attendance-report .branch-totals .total-item {
+  display: flex;
+  align-items: center;
+  gap: 1.5mm;
+}
+
+.monthly-attendance-report .legend-glyph,
+.monthly-attendance-report .total-glyph {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 10mm;
+  height: 6mm;
+  border-radius: 3px;
+  font-weight: 600;
+  font-size: 8pt;
+}
+
+.monthly-attendance-report table.monthly-grid {
+  width: 100%;
+  border-collapse: collapse;
+  table-layout: fixed;
+  font-size: 8.5pt;
+  border: 1px solid #e2e8f0;
+}
+
+.monthly-attendance-report table.monthly-grid thead {
+  background: #f1f5f9;
+  border-bottom: 1px solid #cbd5f5;
+}
+
+.monthly-attendance-report table.monthly-grid thead th {
+  padding: 3mm 2mm;
+  font-weight: 600;
+  font-size: 8pt;
+  color: #0f172a;
+  text-align: center;
+  border-right: 1px solid #e2e8f0;
+  font-variant-numeric: tabular-nums;
+}
+
+.monthly-attendance-report table.monthly-grid tbody td {
+  padding: 2.5mm 2mm;
+  text-align: center;
+  border-right: 1px solid #f1f5f9;
+  border-bottom: 1px solid #f1f5f9;
+  font-variant-numeric: tabular-nums;
+}
+
+.monthly-attendance-report table.monthly-grid th.employee-col,
+.monthly-attendance-report table.monthly-grid td.employee-col {
+  text-align: left;
+  font-weight: 600;
+  width: 32mm;
+}
+
+.monthly-attendance-report table.monthly-grid th.code-col,
+.monthly-attendance-report table.monthly-grid td.code-col {
+  text-align: left;
+  width: 20mm;
+  font-variant-numeric: tabular-nums;
+}
+
+.monthly-attendance-report table.monthly-grid th.assignment-col,
+.monthly-attendance-report table.monthly-grid td.assignment-col {
+  text-align: left;
+  width: 32mm;
+  color: #475569;
+}
+
+.monthly-attendance-report table.monthly-grid td.assignment-col {
+  font-size: 8pt;
+}
+
+.monthly-attendance-report table.monthly-grid th.day-col {
+  width: 9mm;
+}
+
+.monthly-attendance-report table.monthly-grid tbody tr:last-child td {
+  border-bottom: 1px solid #e2e8f0;
+}
+
+.monthly-attendance-report .day-cell {
+  position: relative;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+}
+
+.monthly-attendance-report .day-cell .glyph {
+  display: inline-block;
+  min-width: 6mm;
+}
+
+.monthly-attendance-report .status-present {
+  background: #dcfce7;
+  color: #166534;
+}
+
+.monthly-attendance-report .status-absent {
+  background: #fee2e2;
+  color: #991b1b;
+}
+
+.monthly-attendance-report .status-rest {
+  background: #dbeafe;
+  color: #1d4ed8;
+}
+
+.monthly-attendance-report .status-partial {
+  background: #fef3c7;
+  color: #b45309;
+}
+
+.monthly-attendance-report .status-empty {
+  background: #f8fafc;
+  color: #64748b;
+}
+
+.monthly-attendance-report .day-cell.is-locked::after {
+  content: "";
+  position: absolute;
+  right: 1mm;
+  top: 1mm;
+  width: 2mm;
+  height: 2mm;
+  border-radius: 50%;
+  background: #1e293b;
+}
+
+.monthly-attendance-report .legend-section {
+  page-break-inside: avoid;
+  margin-top: 12mm;
+  border-top: 1px solid #e2e8f0;
+  padding-top: 6mm;
+}
+
+.monthly-attendance-report .legend-grid {
+  display: flex;
+  gap: 6mm;
+  flex-wrap: wrap;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.monthly-attendance-report .legend-grid li {
+  display: flex;
+  align-items: center;
+  gap: 2mm;
+  font-size: 8.5pt;
+}
+
+.monthly-attendance-report .legend-label {
+  color: #334155;
 }
 
 main.report-content {

--- a/attendance/templates/admin/attendance/attday/change_list.html
+++ b/attendance/templates/admin/attendance/attday/change_list.html
@@ -3,5 +3,6 @@
 <li><a class="button" href="{% url 'admin:attendance_attday_calendar' %}">Calendar view</a></li>
 <li><a class="button" href="{% url 'admin:attendance_attday_manual_recompute' %}">Manual recompute</a></li>
 <li><a class="button" href="{% url 'admin:attendance_attday_late_comers_report' %}">Late Comers report</a></li>
+<li><a class="button" href="{% url 'admin:attendance_attday_monthly_report' %}">Monthly attendance report</a></li>
 {{ block.super }}
 {% endblock %}

--- a/attendance/templates/admin/monthly_attendance_report.html
+++ b/attendance/templates/admin/monthly_attendance_report.html
@@ -1,0 +1,81 @@
+{% extends "admin/base_site.html" %}
+{% load i18n %}
+
+{% block breadcrumbs %}
+<div class="breadcrumbs">
+  <a href="{% url 'admin:index' %}">{% trans 'Home' %}</a>
+  › <a href="{% url 'admin:app_list' 'attendance' %}">{% trans 'Attendance' %}</a>
+  › {{ title }}
+</div>
+{% endblock %}
+
+{% block content %}
+<div id="content-main">
+  <h1>{{ title }}</h1>
+  <form method="post" class="form-horizontal">{% csrf_token %}
+    <div class="module aligned">
+      {{ form.non_field_errors }}
+      <fieldset class="form-section">
+        <legend>{% trans "Report month" %}</legend>
+        <div class="form-row">
+          <label for="{{ form.month.id_for_label }}">{{ form.month.label }}</label>
+          <div class="field">
+            {{ form.month.errors }}
+            {{ form.month }}
+            {% if form.month.help_text %}
+              <p class="help">{{ form.month.help_text }}</p>
+            {% endif %}
+          </div>
+        </div>
+      </fieldset>
+      <fieldset class="form-section optional-filters">
+        <legend>{% trans "Optional filters" %}</legend>
+        <p class="help">{% trans "Fine-tune the report by narrowing the employee set." %}</p>
+        <div class="form-row">
+          <label for="{{ form.branch.id_for_label }}">{{ form.branch.label }}</label>
+          <div class="field">
+            {{ form.branch.errors }}
+            {{ form.branch }}
+            <p class="help">{% trans "Limit the report to employees assigned to a branch." %}</p>
+          </div>
+        </div>
+        <div class="form-row">
+          <label for="{{ form.department.id_for_label }}">{{ form.department.label }}</label>
+          <div class="field">
+            {{ form.department.errors }}
+            {{ form.department }}
+            <p class="help">{% trans "Focus on a single department." %}</p>
+          </div>
+        </div>
+        <div class="form-row">
+          <label for="{{ form.project.id_for_label }}">{{ form.project.label }}</label>
+          <div class="field">
+            {{ form.project.errors }}
+            {{ form.project }}
+            <p class="help">{% trans "Filter employees by project assignment." %}</p>
+          </div>
+        </div>
+        <div class="form-row">
+          <label for="{{ form.status.id_for_label }}">{{ form.status.label }}</label>
+          <div class="field">
+            {{ form.status.errors }}
+            {{ form.status }}
+            <p class="help">{% trans "Choose one or more statuses to highlight specific outcomes." %}</p>
+          </div>
+        </div>
+        <div class="form-row">
+          <label for="{{ form.locked.id_for_label }}">{{ form.locked.label }}</label>
+          <div class="field">
+            {{ form.locked.errors }}
+            {{ form.locked }}
+            <p class="help">{% trans "Show only locked or unlocked days when needed." %}</p>
+          </div>
+        </div>
+      </fieldset>
+    </div>
+    <div class="submit-row">
+      <input type="submit" value="{% trans 'Generate' %}" class="default">
+    </div>
+  </form>
+</div>
+{% endblock %}

--- a/attendance/templates/reports/monthly_attendance.html
+++ b/attendance/templates/reports/monthly_attendance.html
@@ -1,0 +1,162 @@
+{% load static %}
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <title>{{ title|default:"Monthly Attendance Report" }}</title>
+</head>
+<body class="report-body monthly-attendance-report">
+  <header class="report-header">
+    <div class="report-header-primary">
+      <h1 class="report-title">{{ title|default:"Monthly attendance report" }}</h1>
+      <p class="report-period">{{ report.month_label }}</p>
+      {% if company %}
+        <p class="report-period">{{ company.name }}</p>
+      {% endif %}
+    </div>
+    <div class="report-meta">
+      <p class="label">Generated</p>
+      <p class="timestamp">{{ generated_at|date:"d M Y H:i" }}</p>
+    </div>
+    {% if logo_url %}
+      <div class="report-logo">
+        <img src="{{ logo_url }}" alt="Company logo" width="120" />
+      </div>
+    {% endif %}
+  </header>
+
+  <footer class="report-footer">
+    <div class="footer-content">
+      <span class="footer-report-title">{{ title|default:"Monthly attendance report" }}</span>
+      <span class="footer-pagination"><span class="page-number"></span></span>
+    </div>
+  </footer>
+
+  <main class="report-content">
+    <section class="report-overview">
+      <div class="report-summary-card">
+        <h2>Monthly totals</h2>
+        <ul class="report-summary-list">
+          {% for item in report.legend_totals %}
+            <li>
+              <span>{{ item.label }}</span>
+              <span>{{ item.count }}</span>
+            </li>
+          {% endfor %}
+          <li>
+            <span>Employees</span>
+            <span>{{ report.employee_count }}</span>
+          </li>
+        </ul>
+      </div>
+      {% if filters %}
+        <div class="report-summary-card">
+          <h2>Filters</h2>
+          <ul class="filters-list">
+            {% if filters.branch %}
+              <li><span class="label">Branch</span>{{ filters.branch|join:", " }}</li>
+            {% endif %}
+            {% if filters.department %}
+              <li><span class="label">Department</span>{{ filters.department|join:", " }}</li>
+            {% endif %}
+            {% if filters.project %}
+              <li><span class="label">Project</span>{{ filters.project|join:", " }}</li>
+            {% endif %}
+            {% if filters.status %}
+              <li><span class="label">Status</span>{{ filters.status|join:", " }}</li>
+            {% endif %}
+            {% if filters.locked %}
+              <li><span class="label">Lock state</span>{{ filters.locked }}</li>
+            {% endif %}
+            {% if not filters.branch and not filters.department and not filters.project and not filters.status and not filters.locked %}
+              <li>All employees in scope</li>
+            {% endif %}
+          </ul>
+        </div>
+      {% endif %}
+    </section>
+
+    {% if report.branch_list %}
+      {% for branch in report.branch_list %}
+        <section class="branch-section">
+          <div class="branch-header">
+            <div>
+              <h2 class="branch-title">{{ branch.name }}</h2>
+              <p class="branch-subtitle">{{ branch.employee_count }} employee{{ branch.employee_count|pluralize }}</p>
+            </div>
+            <div class="branch-totals">
+              {% for item in branch.legend_totals %}
+                <div class="total-item">
+                  <span class="total-glyph {{ item.css_class }}">{{ item.glyph }}</span>
+                  <span>{{ item.count }}</span>
+                </div>
+              {% endfor %}
+            </div>
+          </div>
+          {% if branch.employees %}
+            <table class="monthly-grid">
+              <thead>
+                <tr>
+                  <th class="employee-col">Employee</th>
+                  <th class="code-col">Code</th>
+                  <th class="assignment-col">Assignment</th>
+                  {% for day in report.days %}
+                    <th class="day-col">{{ day.day }}</th>
+                  {% endfor %}
+                </tr>
+                <tr>
+                  <th></th>
+                  <th></th>
+                  <th></th>
+                  {% for day in report.days %}
+                    <th class="day-col">{{ day.weekday }}</th>
+                  {% endfor %}
+                </tr>
+              </thead>
+              <tbody>
+                {% for employee in branch.employees %}
+                  <tr>
+                    <td class="employee-col">{{ employee.display }}</td>
+                    <td class="code-col">{{ employee.metadata.code }}</td>
+                    <td class="assignment-col">
+                      {% if employee.metadata.department %}
+                        {{ employee.metadata.department }}
+                      {% endif %}
+                      {% if employee.metadata.department and employee.metadata.project %}
+                        /
+                      {% endif %}
+                      {% if employee.metadata.project %}
+                        {{ employee.metadata.project }}
+                      {% endif %}
+                    </td>
+                    {% for cell in employee.rows %}
+                      <td class="day-cell {{ cell.css_class }}"><span class="glyph">{{ cell.glyph }}</span></td>
+                    {% endfor %}
+                  </tr>
+                {% endfor %}
+              </tbody>
+            </table>
+          {% else %}
+            <p class="empty-state">No employees matched the selected filters for this branch.</p>
+          {% endif %}
+        </section>
+      {% endfor %}
+    {% else %}
+      <p class="empty-state">No employees matched the selected filters.</p>
+    {% endif %}
+
+    <section class="legend-section">
+      <h2 class="section-title">Legend</h2>
+      <ul class="legend-grid">
+        {% for item in report.legend %}
+          <li>
+            <span class="legend-glyph {{ item.css_class }}">{{ item.glyph }}</span>
+            <span class="legend-label">{{ item.label }}</span>
+          </li>
+        {% endfor %}
+      </ul>
+      <p class="muted">Locked days are marked with a dot in the top-right corner of each cell.</p>
+    </section>
+  </main>
+</body>
+</html>

--- a/attendance/tests/test_attday_admin.py
+++ b/attendance/tests/test_attday_admin.py
@@ -123,3 +123,23 @@ class AttendanceCalendarAdminViewTests(TestCase):
         assert may_first["pairs"]
         assert may_first["adjustments"]
         assert may_first["anomalies"] == {"missing_out_closed_at_next_in": 1}
+
+    def test_monthly_report_form_renders(self):
+        request = self.factory.get("/admin/attendance/attday/monthly-attendance-report/")
+        request.user = self.admin
+        request._cached_user = self.admin
+        response = self.attday_admin.monthly_attendance_report(request)
+        response.render()
+        assert response.status_code == 200
+        assert b"Monthly attendance report" in response.content
+
+    def test_monthly_report_generates_pdf(self):
+        request = self.factory.post(
+            "/admin/attendance/attday/monthly-attendance-report/",
+            {"month": "2024-05"},
+        )
+        request.user = self.admin
+        request._cached_user = self.admin
+        response = self.attday_admin.monthly_attendance_report(request)
+        assert response.status_code == 200
+        assert response["Content-Type"] == "application/pdf"

--- a/attendance/tests/test_attendance_calendar_viewset.py
+++ b/attendance/tests/test_attendance_calendar_viewset.py
@@ -7,6 +7,7 @@ from rest_framework.test import APIClient
 
 from pagasys.models import Company, Branch, Department, Project, Employee
 from attendance.models import AttDay, AttPair, AttAdjustment
+from attendance.services import build_monthly_calendar
 
 
 class AttendanceCalendarViewSetTests(TestCase):
@@ -72,6 +73,11 @@ class AttendanceCalendarViewSetTests(TestCase):
             date=self.day_one,
             work_min=420,
             status="present",
+        )
+        AttDay.objects.create(
+            employee=self.employee_proj,
+            date=self.day_two,
+            status="rest",
         )
 
         AttPair.objects.create(
@@ -241,7 +247,7 @@ class AttendanceCalendarViewSetTests(TestCase):
             format="json",
         )
         assert response.status_code == 200
-        assert response.json()["updated"] == 1
+        assert response.json()["updated"] == 2
         day.refresh_from_db()
         assert day.locked is True
 
@@ -260,3 +266,71 @@ class AttendanceCalendarViewSetTests(TestCase):
         created = AttAdjustment.objects.filter(employee=self.employee_proj).latest("id")
         assert created.delta_work_min == 15
         assert created.created_by_id == self.admin.id
+
+    def test_build_monthly_calendar_report_structure(self):
+        result = build_monthly_calendar(
+            [self.employee_dept, self.employee_proj],
+            "2024-05",
+            user=self.admin,
+            include_pairs=True,
+            include_adjustments=True,
+            include_anomalies=True,
+        )
+        payload = result["payload"]
+        assert payload["month"] == "2024-05"
+        assert len(payload["days"]) == 31
+        report = result["report"]
+        assert report["month_label"] == "May 2024"
+        assert report["legend_totals"]
+        branch_names = [branch["name"] for branch in report["branch_list"]]
+        assert self.branch.name in branch_names
+        branch = report["branch_list"][branch_names.index(self.branch.name)]
+        first_employee = branch["employees"][0]
+        glyphs = {cell["glyph"] for cell in first_employee["rows"]}
+        assert "P" in glyphs
+        assert "-" in glyphs
+        classes = {cell["css_class"] for cell in first_employee["rows"]}
+        assert any("status-present" in value for value in classes)
+        assert branch["legend_totals"][0]["count"] >= 0
+
+    def test_monthly_report_pdf_endpoint(self):
+        url = reverse(
+            "attendance-calendar-monthly-report",
+            kwargs={"company_id": self.company.id},
+        )
+        response = self.client.get(url, {"month": "2024-05"})
+        assert response.status_code == 200
+        assert response["Content-Type"] == "application/pdf"
+        assert "monthly_attendance_2024-05.pdf" in response["Content-Disposition"]
+        assert len(response.content) > 500
+
+    def test_monthly_report_rejects_invalid_month(self):
+        url = reverse(
+            "attendance-calendar-monthly-report",
+            kwargs={"company_id": self.company.id},
+        )
+        response = self.client.get(url, {"month": "not-a-month"})
+        assert response.status_code == 400
+
+    def test_monthly_report_handles_many_employees(self):
+        for idx in range(15):
+            employee = Employee.objects.create_user(
+                username=f"bulk{idx}",
+                password="pass",
+                department=self.department,
+                hire_date=date(2024, 1, 1),
+                employment_type="permanent",
+                visa_type="personal",
+            )
+            AttDay.objects.create(
+                employee=employee,
+                date=self.day_one,
+                status="present",
+            )
+        url = reverse(
+            "attendance-calendar-monthly-report",
+            kwargs={"company_id": self.company.id},
+        )
+        response = self.client.get(url, {"month": "2024-05"})
+        assert response.status_code == 200
+        assert len(response.content) > 1500

--- a/attendance/views.py
+++ b/attendance/views.py
@@ -1,5 +1,4 @@
 import calendar
-from collections import Counter, defaultdict
 from datetime import date, timedelta
 
 from rest_framework import serializers, status, viewsets
@@ -25,14 +24,16 @@ from drf_spectacular.utils import (
 
 from pagasys.openapi_utils import document_filters
 from pagasys.utils import scope_queryset
-from pagasys.models import Employee
+from pagasys.models import Employee, Company, Branch, Department, Project
 from django.http import HttpResponse
 
 from .models import AttDay, AttPair, AttAdjustment
+from .services import build_monthly_calendar
 from .reports import (
     get_late_comers,
     group_late_comers,
     render_late_comers_pdf,
+    render_monthly_attendance_pdf,
 )
 from .serializers import (
     AttDaySerializer,
@@ -51,9 +52,6 @@ from .tasks import (
 MAX_RANGE_DAYS = 31
 MAX_EMPLOYEES = 50
 CALENDAR_PAGE_SIZE = 200
-LOCKED_REASON = "Attendance day is locked; adjustments are disabled."
-
-
 class AttendanceCalendarMetricsDocSerializer(serializers.Serializer):
     work_min = serializers.IntegerField(help_text="Computed work minutes for the day")
     unpaid_break_min = serializers.IntegerField(help_text="Unpaid break minutes deducted")
@@ -243,6 +241,13 @@ ATTENDANCE_CALENDAR_QUERY_PARAMS = [
     ),
 ]
 
+MONTHLY_REPORT_QUERY_PARAMS = [
+    param
+    for param in ATTENDANCE_CALENDAR_QUERY_PARAMS
+    if param.name
+    in {"month", "employee", "branch", "department", "project", "status", "locked"}
+]
+
 ATTENDANCE_CALENDAR_EXAMPLE = OpenApiExample(
     "Calendar grid",
     value={
@@ -384,6 +389,15 @@ def parse_int_list(value):
 
 
 class LateComersPDFRenderer(BaseRenderer):
+    media_type = "application/pdf"
+    format = "pdf"
+    charset = None
+
+    def render(self, data, accepted_media_type=None, renderer_context=None):
+        return data
+
+
+class MonthlyAttendancePDFRenderer(BaseRenderer):
     media_type = "application/pdf"
     format = "pdf"
     charset = None
@@ -611,6 +625,7 @@ class AttDayViewSet(viewsets.ReadOnlyModelViewSet):
         response = HttpResponse(pdf, content_type="application/pdf")
         response["Content-Disposition"] = f"attachment; filename={filename}"
         return response
+
 
 
 @extend_schema_view(
@@ -913,160 +928,54 @@ class AttendanceCalendarViewSet(viewsets.GenericViewSet):
         self.cursor_ordering = ordering
         return queryset
 
-    def _build_calendar_response(
-        self,
-        employees,
-        start,
-        end,
-        *,
-        include_pairs,
-        include_adjustments,
-        include_anomalies,
-        stats_only,
-        status_filters,
-        locked_filter,
-    ):
-        days = [start + timedelta(days=offset) for offset in range((end - start).days + 1)]
-        employee_ids = [employee.id for employee in employees]
-        request = self.request
-        context = self.get_serializer_context()
-
-        day_map = defaultdict(dict)
-        if employee_ids:
-            day_qs = (
-                AttDay.objects.filter(employee_id__in=employee_ids, date__range=(start, end))
-                .select_related("shift", "roster")
-            )
-            day_qs = scope_queryset(day_qs, request.user)
-            if status_filters:
-                day_qs = day_qs.filter(status__in=status_filters)
-            if locked_filter is not None:
-                day_qs = day_qs.filter(locked=locked_filter)
-            for day in day_qs:
-                day_map[day.employee_id][day.date] = day
-
-        valid_keys = {(emp_id, day) for emp_id, entries in day_map.items() for day in entries.keys()}
-
-        pairs_data = {}
-        if include_pairs and not stats_only and valid_keys:
-            pair_qs = AttPair.objects.filter(
-                employee_id__in=employee_ids, date__range=(start, end)
-            ).order_by("in_ts")
-            pair_qs = scope_queryset(pair_qs, request.user)
-            grouped_pairs = defaultdict(list)
-            valid_dates = {key[1] for key in valid_keys}
-            pair_qs = pair_qs.filter(date__in=valid_dates)
-            for pair in pair_qs:
-                key = (pair.employee_id, pair.date)
-                if key in valid_keys:
-                    grouped_pairs[key].append(pair)
-            for key, records in grouped_pairs.items():
-                pairs_data[key] = AttPairSerializer(records, many=True, context=context).data
-
-        adjustments_data = {}
-        if include_adjustments and not stats_only and valid_keys:
-            adjustment_qs = AttAdjustment.objects.filter(
-                employee_id__in=employee_ids, date__range=(start, end)
-            ).order_by("created_at")
-            adjustment_qs = scope_queryset(adjustment_qs, request.user)
-            grouped_adjustments = defaultdict(list)
-            valid_dates = {key[1] for key in valid_keys}
-            adjustment_qs = adjustment_qs.filter(date__in=valid_dates)
-            for adjustment in adjustment_qs:
-                key = (adjustment.employee_id, adjustment.date)
-                if key in valid_keys:
-                    grouped_adjustments[key].append(adjustment)
-            for key, records in grouped_adjustments.items():
-                adjustments_data[key] = AttAdjustmentSerializer(
-                    records, many=True, context=context
-                ).data
-
-        employees_payload = []
-        for employee in employees:
-            employee_days = day_map.get(employee.id, {})
-            summary_counts = Counter()
-            locked_days = 0
-            total_ot = 0
-            rows = []
-
-            for current_day in days:
-                day = employee_days.get(current_day)
-                if day:
-                    summary_counts[day.status] += 1
-                    if day.locked:
-                        locked_days += 1
-                    total_ot += day.ot_regular_min + day.ot_night_min + day.ot_holiday_min
-                if stats_only:
-                    continue
-
-                key = (employee.id, current_day)
-                row = {
-                    "date": current_day.isoformat(),
-                    "status": day.status if day else None,
-                    "locked": bool(day.locked) if day else False,
-                    "locked_reason": LOCKED_REASON if day and day.locked else None,
-                    "metrics": {
-                        "work_min": day.work_min if day else 0,
-                        "unpaid_break_min": day.unpaid_break_min if day else 0,
-                        "paid_break_min": day.paid_break_min if day else 0,
-                        "late_min": day.late_min if day else 0,
-                        "early_leave_min": day.early_leave_min if day else 0,
-                        "ot_regular_min": day.ot_regular_min if day else 0,
-                        "ot_night_min": day.ot_night_min if day else 0,
-                        "ot_holiday_min": day.ot_holiday_min if day else 0,
-                        "on_leave": day.on_leave if day else False,
-                        "leave_portion": float(day.leave_portion) if day else 0.0,
-                        "is_holiday": day.is_holiday if day else False,
-                        "is_rest_day": day.is_rest_day if day else False,
-                        "pairs_count": day.pairs_count if day else 0,
-                        "punches_used": day.punches_used if day else 0,
-                    },
-                }
-                if include_anomalies:
-                    row["anomalies"] = day.anomalies if day else {}
-                if include_pairs:
-                    row["pairs"] = pairs_data.get(key, [])
-                if include_adjustments:
-                    row["adjustments"] = adjustments_data.get(key, [])
-                rows.append(row)
-
-            summary = {
-                "present": summary_counts.get("present", 0),
-                "absent": summary_counts.get("absent", 0),
-                "leave": summary_counts.get("leave", 0),
-                "holiday": summary_counts.get("holiday", 0),
-                "rest": summary_counts.get("rest", 0),
-                "partial": summary_counts.get("partial", 0),
-                "locked_days": locked_days,
-                "total_ot_min": total_ot,
-            }
-
-            branch = None
-            if employee.department and employee.department.branch:
-                branch = employee.department.branch
-            elif employee.project and employee.project.branch:
-                branch = employee.project.branch
-
-            employees_payload.append(
-                {
-                    "id": employee.id,
-                    "display": employee.get_full_name().strip() or employee.username,
-                    "metadata": {
-                        "department": employee.department.name if employee.department else None,
-                        "project": employee.project.name if employee.project else None,
-                        "branch": branch.name if branch else None,
-                        "code": employee.username,
-                    },
-                    "rows": [] if stats_only else rows,
-                    "summary": summary,
-                }
-            )
-
-        return {
-            "month": start.strftime("%Y-%m"),
-            "days": [day.isoformat() for day in days],
-            "employees": employees_payload,
+    def _summarise_report_filters(self, request, company_id, status_filters, locked_filter):
+        summary = {
+            "branch": [],
+            "department": [],
+            "project": [],
+            "status": [],
+            "locked": "",
         }
+
+        branch_ids = parse_int_list(request.query_params.getlist("branch"))
+        if branch_ids:
+            branch_qs = Branch.objects.filter(id__in=branch_ids)
+            if company_id:
+                branch_qs = branch_qs.filter(company_id=company_id)
+            branch_qs = scope_queryset(branch_qs, request.user)
+            summary["branch"] = list(branch_qs.order_by("name").values_list("name", flat=True))
+
+        department_ids = parse_int_list(request.query_params.getlist("department"))
+        if department_ids:
+            dept_qs = Department.objects.filter(id__in=department_ids)
+            if company_id:
+                dept_qs = dept_qs.filter(branch__company_id=company_id)
+            dept_qs = scope_queryset(dept_qs, request.user)
+            summary["department"] = list(
+                dept_qs.order_by("name").values_list("name", flat=True)
+            )
+
+        project_ids = parse_int_list(request.query_params.getlist("project"))
+        if project_ids:
+            project_qs = Project.objects.filter(id__in=project_ids)
+            if company_id:
+                project_qs = project_qs.filter(branch__company_id=company_id)
+            project_qs = scope_queryset(project_qs, request.user)
+            summary["project"] = list(
+                project_qs.order_by("name").values_list("name", flat=True)
+            )
+
+        status_labels = dict(AttDay._meta.get_field("status").choices)
+        if status_filters:
+            summary["status"] = [status_labels.get(code, code) for code in status_filters]
+
+        if locked_filter is True:
+            summary["locked"] = "Locked only"
+        elif locked_filter is False:
+            summary["locked"] = "Unlocked only"
+
+        return summary
+
 
     def list(self, request, company_id=None):
         start, end = parse_month(request.query_params.get("month"))
@@ -1097,17 +1006,19 @@ class AttendanceCalendarViewSet(viewsets.GenericViewSet):
         if page is None and len(employees) > CALENDAR_PAGE_SIZE:
             employees = employees[:CALENDAR_PAGE_SIZE]
 
-        payload = self._build_calendar_response(
+        calendar_result = build_monthly_calendar(
             employees,
-            start,
-            end,
+            (start, end),
+            user=request.user,
             include_pairs=include_pairs,
             include_adjustments=include_adjustments,
             include_anomalies=include_anomalies,
             stats_only=stats_only,
             status_filters=status_filters,
             locked_filter=locked_filter,
+            serializer_context=self.get_serializer_context(),
         )
+        payload = calendar_result["payload"]
 
         if getattr(self, "paginator", None) and getattr(self.paginator, "page", None) is not None:
             payload["next"] = self.paginator.get_next_link()
@@ -1141,18 +1052,93 @@ class AttendanceCalendarViewSet(viewsets.GenericViewSet):
         if not employee:
             raise NotFound("Employee not found")
 
-        payload = self._build_calendar_response(
+        calendar_result = build_monthly_calendar(
             [employee],
-            start,
-            end,
+            (start, end),
+            user=request.user,
             include_pairs=include_pairs,
             include_adjustments=include_adjustments,
             include_anomalies=include_anomalies,
             stats_only=stats_only,
             status_filters=status_filters,
             locked_filter=locked_filter,
+            serializer_context=self.get_serializer_context(),
         )
+        payload = calendar_result["payload"]
         return Response(payload)
+
+    @extend_schema(
+        summary="Download a monthly attendance PDF report",
+        description=(
+            "Generate a landscape PDF that groups employees by branch and renders a day-by-day "
+            "attendance grid using compact glyphs. The report honours the same filtering options "
+            "as the calendar API (branch, department, project, status, locked)."
+        ),
+        parameters=MONTHLY_REPORT_QUERY_PARAMS,
+        responses={
+            200: OpenApiResponse(
+                response=OpenApiTypes.BINARY,
+                description="PDF file containing the monthly attendance grid.",
+            )
+        },
+    )
+    @action(
+        detail=False,
+        methods=["get"],
+        url_path="monthly-report",
+        renderer_classes=[MonthlyAttendancePDFRenderer],
+    )
+    def monthly_report(self, request, company_id=None):
+        start, end = parse_month(request.query_params.get("month"))
+
+        status_param = request.query_params.get("status")
+        status_filters = (
+            [value.strip() for value in status_param.split(",") if value.strip()]
+            if status_param
+            else []
+        )
+
+        locked_filter = None
+        if "locked" in request.query_params:
+            locked_filter = parse_bool(request.query_params.get("locked"))
+
+        queryset = self._filter_employees(self.get_queryset(), request, company_id)
+        queryset = self._apply_sorting(queryset, request)
+        employees = list(queryset)
+
+        calendar_result = build_monthly_calendar(
+            employees,
+            (start, end),
+            user=request.user,
+            include_pairs=False,
+            include_adjustments=False,
+            include_anomalies=False,
+            stats_only=False,
+            status_filters=status_filters,
+            locked_filter=locked_filter,
+            serializer_context=self.get_serializer_context(),
+        )
+        report_data = calendar_result["report"]
+
+        filters_summary = self._summarise_report_filters(
+            request, company_id, status_filters, locked_filter
+        )
+
+        company = None
+        if company_id:
+            company = Company.objects.filter(pk=company_id).first()
+
+        pdf_context = {
+            "request": request,
+            "company": company,
+            "filters": filters_summary,
+        }
+        pdf = render_monthly_attendance_pdf(report_data, pdf_context)
+        filename = f"monthly_attendance_{report_data['month']}.pdf"
+        return Response(
+            pdf,
+            headers={"Content-Disposition": f"attachment; filename={filename}"},
+        )
 
     @action(detail=False, methods=["post"], url_path="lock")
     @extend_schema(

--- a/docs/attendance_reports.md
+++ b/docs/attendance_reports.md
@@ -52,3 +52,66 @@ Late-comer queries use a `(date, late_min)` database index and `select_related`
 joins for employee, department, project and shift relations. For very large date
 ranges consider chunking the request to avoid excessive memory usage. Concurrent
 requests generate PDFs independently and do not share state.
+
+---
+
+# Monthly Attendance PDF Report
+
+Summarise employee attendance for an entire month in a landscape PDF designed
+for printing or archival storage. The report groups employees by branch, renders
+a compact status grid for each day, and surfaces per-branch as well as
+organisation-wide totals.
+
+## API
+
+`GET /api/companies/{company_id}/attendance-calendar/monthly-report/?month=YYYY-MM`
+
+Supported query parameters mirror the calendar API filters:
+
+| name | required | notes |
+| ---- | -------- | ----- |
+| `month` | yes | `YYYY-MM` month to aggregate |
+| `branch` | no | branch ID (repeatable or comma separated) |
+| `department` | no | department ID filter |
+| `project` | no | project ID filter |
+| `employee` | no | restrict to one or more employee IDs |
+| `status` | no | comma-separated list of `AttDay.status` values |
+| `locked` | no | `true` for locked days, `false` for unlocked |
+
+Example:
+
+```bash
+curl -L -o attendance.pdf \
+  -H "Authorization: Token <token>" \
+  "/api/companies/1/attendance-calendar/monthly-report/?month=2024-05&branch=3"
+```
+
+## Admin
+
+Open **Attendance → Att days → Monthly attendance report**. Choose a month and
+any optional filters, then click **Generate**. The PDF downloads immediately and
+respects the admin user's scope, preventing access to out-of-branch data.
+
+## Output
+
+Each branch section includes the employee count, per-status totals, and a table
+with one row per employee. Day cells use glyphs to stay readable when printed:
+
+| Glyph | Meaning | CSS class |
+| ----- | ------- | --------- |
+| `P` | Present | `.status-present` |
+| `A` | Absent / leave | `.status-absent` |
+| `R` | Rest / holiday | `.status-rest` |
+| `T` | Partial | `.status-partial` |
+| `-` | No data | `.status-empty` |
+
+Locked days display a small dot in the corner for quick auditing. A legend at
+the bottom of the PDF repeats the glyph mapping and the report header/footers
+match the existing late-comers design for consistency.
+
+## Performance
+
+The calendar aggregation is shared with the API, so database access is limited
+to scoped `AttDay`, `AttPair`, and `AttAdjustment` queries. Reports stream
+directly to WeasyPrint and naturally span multiple pages when branches contain a
+large number of employees.

--- a/tests/test_attendance_rules.py
+++ b/tests/test_attendance_rules.py
@@ -534,6 +534,23 @@ class AdjustmentTests(AttendanceBase):
         self.assertEqual(day.status, "leave")
         self.assertTrue(day.anomalies.get("manual_adjustments_applied"))
 
+    def test_adjustment_without_override_updates_status(self):
+        day = self.compute()
+        self.assertEqual(day.status, "absent")
+
+        AttAdjustment.objects.create(
+            employee=self.employee,
+            date=self.day,
+            delta_work_min=8 * 60,
+            reason="make_present",
+            created_by_id=1,
+        )
+
+        day = self.compute()
+        self.assertEqual(day.status, "present")
+        self.assertEqual(day.work_min, 8 * 60)
+        self.assertTrue(day.anomalies.get("manual_adjustments_applied"))
+
     def test_adjustment_idempotent(self):
         self.punch(time(9, 0), "in")
         self.punch(time(17, 0), "out")


### PR DESCRIPTION
## Summary
- add a reusable `build_monthly_calendar` service that returns both API payloads and branch-level report data with glyph counts
- expose a `monthly-report` PDF action and renderer that uses the new WeasyPrint template and extended report styling
- wire the monthly report into the admin via a scoped form, dedicated template, change list shortcut, and updated docs/tests
- ensure attendance recomputation promotes statuses after manual adjustments so the monthly PDF treats adjusted days as present when appropriate

## Testing
- `DJANGO_SETTINGS_MODULE=config.settings.test python manage.py test tests.test_attendance_rules attendance.tests.test_attendance_calendar_viewset attendance.tests.test_attday_admin attendance.tests.test_reports`

------
https://chatgpt.com/codex/tasks/task_e_68cabc588ff4832d96c16634fbe4c3a8