### PR TITLE
Adjust monthly attendance report layout

### DIFF
--- a/attendance/static/attendance/css/reports.css
+++ b/attendance/static/attendance/css/reports.css
@@ -170,11 +170,6 @@ p {
 }
 
 .monthly-attendance-report .branch-header {
-  display: flex;
-  justify-content: space-between;
-  align-items: flex-end;
-  gap: 6mm;
-  flex-wrap: wrap;
   margin-bottom: 4mm;
   border-bottom: 1px solid #e2e8f0;
   padding-bottom: 2mm;
@@ -190,23 +185,17 @@ p {
 }
 
 .monthly-attendance-report .branch-subtitle {
-  margin: 0;
+  margin: 1mm 0 0;
   font-size: 9pt;
   color: #475569;
 }
 
-.monthly-attendance-report .branch-totals {
-  display: flex;
-  gap: 5mm;
-  flex-wrap: wrap;
-  align-items: center;
-  font-size: 8.5pt;
+.monthly-attendance-report .monthly-grid-group {
+  display: block;
 }
 
-.monthly-attendance-report .monthly-grid-group {
-  display: flex;
-  flex-direction: column;
-  gap: 6mm;
+.monthly-attendance-report .monthly-grid-wrapper + .monthly-grid-wrapper {
+  margin-top: 6mm;
 }
 
 .monthly-attendance-report .monthly-grid-wrapper {
@@ -218,14 +207,7 @@ p {
   margin-top: -2mm;
 }
 
-.monthly-attendance-report .branch-totals .total-item {
-  display: flex;
-  align-items: center;
-  gap: 1.5mm;
-}
-
-.monthly-attendance-report .legend-glyph,
-.monthly-attendance-report .total-glyph {
+.monthly-attendance-report .legend-glyph {
   display: inline-flex;
   align-items: center;
   justify-content: center;

--- a/attendance/templates/reports/monthly_attendance.html
+++ b/attendance/templates/reports/monthly_attendance.html
@@ -27,18 +27,8 @@
       {% for branch in report.branch_list %}
         <section class="branch-section">
           <div class="branch-header">
-            <div>
-              <h2 class="branch-title">{{ branch.name }}</h2>
-              <p class="branch-subtitle">{{ branch.employee_count }} employee{{ branch.employee_count|pluralize }}</p>
-            </div>
-            <div class="branch-totals">
-              {% for item in branch.legend_totals %}
-                <div class="total-item">
-                  <span class="total-glyph {{ item.css_class }}">{{ item.glyph }}</span>
-                  <span>{{ item.count }}</span>
-                </div>
-              {% endfor %}
-            </div>
+            <h2 class="branch-title">{{ branch.name }}</h2>
+            <p class="branch-subtitle">{{ branch.employee_count }} employee{{ branch.employee_count|pluralize }}</p>
           </div>
           {% if branch.employees %}
             <div class="monthly-grid-group">


### PR DESCRIPTION
## Summary
- remove the branch-level totals block so branch pages start with the branch name and headcount
- update the monthly attendance PDF styles to drop flex layouts and rely on block spacing so tables begin on the first page and break cleanly

## Testing
- pytest attendance/tests/test_attendance_calendar_viewset.py::AttendanceCalendarViewSetTests::test_monthly_report_pdf_endpoint -q

------
https://chatgpt.com/codex/tasks/task_e_68cc01f54e34832d8cd0e2f0386c66cd