### PR TITLE
Add all=true escape hatch to DRF pagination

### DIFF
--- a/attendance/admin.py
+++ b/attendance/admin.py
@@ -289,6 +289,9 @@ class AttDayAdmin(ScopedAdminMixin, admin.ModelAdmin):
         queryset = viewset._apply_sorting(queryset, drf_request)
 
         page = viewset.paginate_queryset(queryset)
+        paginator = getattr(viewset, "paginator", None)
+        all_requested = bool(getattr(paginator, "all_requested", False)) if paginator else False
+
         employees = []
         using_pagination = False
         if page is not None:
@@ -297,10 +300,12 @@ class AttDayAdmin(ScopedAdminMixin, admin.ModelAdmin):
             if not employees and queryset.exists():
                 employees = list(queryset[:CALENDAR_PAGE_SIZE])
                 using_pagination = False
+        elif all_requested:
+            employees = list(queryset)
         else:
             employees = list(queryset[:CALENDAR_PAGE_SIZE])
 
-        if not using_pagination and len(employees) > CALENDAR_PAGE_SIZE:
+        if not using_pagination and not all_requested and len(employees) > CALENDAR_PAGE_SIZE:
             employees = employees[:CALENDAR_PAGE_SIZE]
 
         calendar_result = build_monthly_calendar(

--- a/attendance/tests/test_attendance_calendar_viewset.py
+++ b/attendance/tests/test_attendance_calendar_viewset.py
@@ -1,4 +1,5 @@
 from datetime import date, datetime, time
+from unittest import mock
 
 from django.test import TestCase
 from django.urls import reverse
@@ -220,6 +221,47 @@ class AttendanceCalendarViewSetTests(TestCase):
         payload = response.json()
         ids = [emp["id"] for emp in payload["employees"]]
         assert ids == [self.employee_proj.id]
+
+    def test_calendar_list_all_param_disables_pagination(self):
+        extra_employees = [
+            Employee.objects.create_user(
+                username=f"bulk{i}",
+                password="pass",
+                first_name=f"Extra{i}",
+                last_name="User",
+                department=self.department,
+                hire_date=date(2024, 1, 1),
+                employment_type="permanent",
+                visa_type="personal",
+            )
+            for i in range(3)
+        ]
+
+        with mock.patch("attendance.views.CALENDAR_PAGE_SIZE", 1), mock.patch(
+            "attendance.views.AttendanceCalendarPagination.page_size",
+            1,
+        ):
+            paginated = self.client.get(
+                self._list_url(),
+                {"month": "2024-05"},
+            )
+            assert paginated.status_code == 200
+            payload = paginated.json()
+            assert len(payload["employees"]) == 1
+            assert payload.get("next")
+
+            unpaginated = self.client.get(
+                self._list_url(),
+                {"month": "2024-05", "all": "true"},
+            )
+            assert unpaginated.status_code == 200
+            payload_all = unpaginated.json()
+            expected_count = Employee.objects.filter(is_superuser=False).count()
+            assert len(payload_all["employees"]) == expected_count
+            assert "next" not in payload_all
+
+        for employee in extra_employees:
+            employee.delete()
 
     def test_calendar_stats_only_returns_empty_rows(self):
         response = self.client.get(

--- a/attendance/views.py
+++ b/attendance/views.py
@@ -25,6 +25,7 @@ from drf_spectacular.utils import (
 from pagasys.openapi_utils import document_filters
 from pagasys.utils import scope_queryset
 from pagasys.models import Employee, Company, Branch, Department, Project
+from pagasys.pagination import AllRecordsMixin
 from django.http import HttpResponse
 
 from .models import AttDay, AttPair, AttAdjustment
@@ -334,7 +335,7 @@ ATTENDANCE_CALENDAR_EXAMPLE = OpenApiExample(
 )
 
 
-class AttendanceCalendarPagination(CursorPagination):
+class AttendanceCalendarPagination(AllRecordsMixin, CursorPagination):
     page_size = CALENDAR_PAGE_SIZE
     ordering = ("first_name", "last_name", "username", "id")
 
@@ -1015,9 +1016,17 @@ class AttendanceCalendarViewSet(viewsets.GenericViewSet):
         queryset = self._apply_sorting(queryset, request)
 
         page = self.paginate_queryset(queryset)
-        employees = list(page if page is not None else queryset[:CALENDAR_PAGE_SIZE])
-        if page is None and len(employees) > CALENDAR_PAGE_SIZE:
-            employees = employees[:CALENDAR_PAGE_SIZE]
+        paginator = getattr(self, "paginator", None)
+        all_requested = bool(getattr(paginator, "all_requested", False)) if paginator else False
+
+        if page is not None:
+            employees = list(page)
+        elif all_requested:
+            employees = list(queryset)
+        else:
+            employees = list(queryset[:CALENDAR_PAGE_SIZE])
+            if len(employees) > CALENDAR_PAGE_SIZE:
+                employees = employees[:CALENDAR_PAGE_SIZE]
 
         calendar_result = build_monthly_calendar(
             employees,

--- a/pagasys/pagination.py
+++ b/pagasys/pagination.py
@@ -1,8 +1,42 @@
 from django.conf import settings
+from rest_framework import exceptions
 from rest_framework.pagination import PageNumberPagination
 
 
-class GlobalPagination(PageNumberPagination):
+class AllRecordsMixin:
+    """Allow list endpoints to return every record when ``all=true`` is requested."""
+
+    all_query_param = "all"
+    truthy_values = {"1", "true", "yes", "on"}
+    falsy_values = {"0", "false", "no", "off"}
+
+    def _should_return_all(self, request):
+        if request is None:
+            return False
+        value = request.query_params.get(self.all_query_param)
+        if value is None:
+            return False
+        if isinstance(value, bool):
+            return value
+        coerced = str(value).strip().lower()
+        if coerced in self.truthy_values:
+            return True
+        if coerced in self.falsy_values:
+            return False
+        raise exceptions.ValidationError(
+            {self.all_query_param: [f"Invalid boolean value '{value}'"]}
+        )
+
+    def get_page_size(self, request):
+        should_return_all = self._should_return_all(request)
+        # ``all_requested`` is introspected by list views that perform additional slicing.
+        self.all_requested = should_return_all
+        if should_return_all:
+            return None
+        return super().get_page_size(request)
+
+
+class GlobalPagination(AllRecordsMixin, PageNumberPagination):
     """Global pagination allowing clients to control page size."""
 
     page_size_query_param = "page_size"

--- a/pagasys/tests/test_pagination_warning.py
+++ b/pagasys/tests/test_pagination_warning.py
@@ -109,6 +109,28 @@ class PaginationWarningTests(TestCase):
         for url in endpoints:
             self._check_endpoint(url)
 
+    def test_all_query_param_returns_full_collection(self):
+        base_url = "/api/companies/"
+        paginated = self.client.get(base_url, {"page_size": 1})
+        self.assertEqual(paginated.status_code, 200)
+        payload = paginated.json()
+        self.assertIn("results", payload)
+        self.assertEqual(len(payload["results"]), 1)
+        self.assertNotEqual(payload.get("next"), None)
+
+        unpaginated = self.client.get(base_url, {"page_size": 1, "all": "true"})
+        self.assertEqual(unpaginated.status_code, 200)
+        data = unpaginated.json()
+        self.assertIsInstance(data, list)
+        self.assertEqual(len(data), Company.objects.count())
+
+    def test_all_query_param_requires_boolean(self):
+        response = self.client.get("/api/companies/", {"all": "maybe"})
+        self.assertEqual(response.status_code, 400)
+        payload = response.json()
+        self.assertIn("errors", payload)
+        self.assertIn("all", payload["errors"])
+
 
 class ModelOrderingTests(TestCase):
     def test_meta_ordering_defined(self):


### PR DESCRIPTION
## Summary
- add an AllRecordsMixin that lets DRF pagination classes honour an `all=true` query parameter
- use the mixin for the global page-number paginator and the attendance cursor paginator, updating views/admin flows to bypass slicing when all results are requested
- cover the new behaviour with API regression tests for both standard listings and the attendance calendar, including invalid input handling

## Testing
- python manage.py test pagasys.tests.test_pagination_warning attendance.tests.test_attendance_calendar_viewset

------
https://chatgpt.com/codex/tasks/task_e_68cc03b862dc832d9bb2eac8f10cdeb7