### PR TITLE
Add single company mode flag and update API docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,10 @@ comprehensive automated test suite.
 * **Company bank accounts** – Each company can record a bank account number for
   payroll deposits. The field is exposed through the API and a dedicated
   "Financial details" section in the admin.
+* **Single company mode** – Toggle the `is_only_company` flag to lock the
+  tenant into a single-company configuration. When enabled, creating additional
+  companies through the API or admin is blocked to keep the deployment scoped
+  to one organisation.
 * **Employee notes** – Special notes about employees can be stored and
   managed via the API and Django admin.
 * **Employee full names** – Employee records now support separate first,

--- a/pagasys/admin.py
+++ b/pagasys/admin.py
@@ -212,7 +212,7 @@ class CompanyAdmin(CleanSaveModelMixin, ScopedAdminMixin, admin.ModelAdmin):
 
     list_filter = ["name"]
     fieldsets = (
-        (None, {"fields": ("name", "timezone")}),
+        (None, {"fields": ("name", "timezone", "is_only_company")}),
         (
             "Contact details",
             {

--- a/pagasys/migrations/0034_company_is_only_company.py
+++ b/pagasys/migrations/0034_company_is_only_company.py
@@ -1,0 +1,22 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("pagasys", "0033_alter_employee_c3_id_alter_employee_payment_status_and_more"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="company",
+            name="is_only_company",
+            field=models.BooleanField(
+                default=False,
+                help_text=(
+                    "When enabled, this instance represents the sole company and "
+                    "blocks creation of any additional companies."
+                ),
+            ),
+        ),
+    ]

--- a/pagasys/models.py
+++ b/pagasys/models.py
@@ -54,6 +54,13 @@ class Company(models.Model):
         blank=True,
         help_text="Bank account number used for payroll transactions",
     )
+    is_only_company = models.BooleanField(
+        default=False,
+        help_text=(
+            "When enabled, this instance represents the sole company and "
+            "blocks creation of any additional companies."
+        ),
+    )
 
     class Meta:
         verbose_name_plural = "companies"
@@ -68,6 +75,25 @@ class Company(models.Model):
             ZoneInfo(self.timezone)
         except ZoneInfoNotFoundError:
             raise ValidationError({"timezone": "Invalid IANA time zone (e.g., 'Asia/Dubai')"})
+        other_companies = Company.objects.exclude(pk=self.pk)
+        if self.is_only_company and other_companies.exists():
+            raise ValidationError(
+                {
+                    "is_only_company": (
+                        "Cannot mark this company as the only company while other companies exist. "
+                        "Delete or archive the others first."
+                    )
+                }
+            )
+        if not self.is_only_company and other_companies.filter(is_only_company=True).exists():
+            raise ValidationError(
+                {
+                    "is_only_company": (
+                        "Another company is marked as the only company. "
+                        "Unset that flag before adding or updating additional companies."
+                    )
+                }
+            )
 
     def __str__(self) -> str:
         return self.name

--- a/pagasys/serializers.py
+++ b/pagasys/serializers.py
@@ -116,6 +116,17 @@ class CompanySerializer(ScopedSerializerMixin, serializers.ModelSerializer):
         model = Company
         fields = '__all__'
 
+    def validate(self, attrs):
+        attrs = super().validate(attrs)
+        if self.instance is not None:
+            data = {f.name: getattr(self.instance, f.name) for f in Company._meta.fields}
+            data.update(attrs)
+        else:
+            data = attrs
+        instance = Company(**data)
+        instance.clean()
+        return attrs
+
 
 class BranchSerializer(ScopedSerializerMixin, serializers.ModelSerializer):
     """Serializer for Branch"""

--- a/pagasys/views.py
+++ b/pagasys/views.py
@@ -231,6 +231,7 @@ class CompanyViewSet(BulkCreateMixin, BulkUpdateMixin, BulkDeleteMixin, viewsets
     filterset_fields = [
         "name",
         "timezone",
+        "is_only_company",
         "address",
         "email",
         "phone",

--- a/tests/swagger/openapi.yaml
+++ b/tests/swagger/openapi.yaml
@@ -643,6 +643,15 @@ paths:
           Example:
             value: <value>
       - in: query
+        name: is_only_company
+        schema:
+          type: string
+        description: Filter by is_only_company. Combine multiple parameters for compound
+          filtering.
+        examples:
+          Example:
+            value: <value>
+      - in: query
         name: name
         schema:
           type: string
@@ -10205,6 +10214,10 @@ components:
           type: string
           description: Bank account number used for payroll transactions
           maxLength: 64
+        is_only_company:
+          type: boolean
+          description: When enabled, this instance represents the sole company and
+            blocks creation of any additional companies.
       required:
       - id
       - name
@@ -12552,6 +12565,10 @@ components:
           type: string
           description: Bank account number used for payroll transactions
           maxLength: 64
+        is_only_company:
+          type: boolean
+          description: When enabled, this instance represents the sole company and
+            blocks creation of any additional companies.
     PatchedDepartment:
       type: object
       description: Serializer for Department


### PR DESCRIPTION
## Summary
- add an `is_only_company` flag to companies with validation enforcing single-company mode
- expose the flag through serializers, filtering, Django admin, and API documentation
- regenerate the bundled OpenAPI schema and document the option in the README

## Testing
- python manage.py test pagasys.tests.test_schema


------
https://chatgpt.com/codex/tasks/task_e_68cc33c756dc832db01385e7be6de6b1