### PR TITLE
Ignore unpaired-out pairs when computing lateness

### DIFF
--- a/attendance/services.py
+++ b/attendance/services.py
@@ -378,8 +378,22 @@ def compute_att_day(employee_id: int, day: date) -> int:
     )
 
     if shift and not on_leave:
-        first_in = next((p.in_ts for p in pairs if p.in_ts), None)
-        last_out = next((p.out_ts for p in reversed(pairs) if p.out_ts), None)
+        first_in = next(
+            (
+                p.in_ts
+                for p in pairs
+                if p.in_ts and not bool((p.anomaly or {}).get("unpaired_out"))
+            ),
+            None,
+        )
+        last_out = next(
+            (
+                p.out_ts
+                for p in reversed(pairs)
+                if p.out_ts and not bool((p.anomaly or {}).get("unpaired_out"))
+            ),
+            None,
+        )
         if first_in:
             first_in = timezone.localtime(first_in, tz)
             sched_start = datetime.combine(day, shift.start_time, tzinfo=tz)

--- a/tests/test_attendance_rules.py
+++ b/tests/test_attendance_rules.py
@@ -7,6 +7,7 @@ from django.utils import timezone
 from django.core.exceptions import ValidationError
 from zoneinfo import ZoneInfo
 
+from attendance.reports import get_late_comers
 from attendance.services import build_pairs_for, compute_att_day
 from attendance.services_helpers import active_rules
 from capture.models import AttendanceDevice, PunchEvent
@@ -116,6 +117,17 @@ class AutoEventSequenceAnomalyTests(AttendanceBase):
         self.punch(time(17, 0), "out")
         day = self.compute()
         self.assertEqual(day.anomalies.get("unpaired_out"), 1)
+
+    def test_stray_out_before_in_does_not_trigger_late(self):
+        self.punch(time(8, 30), "out")
+        self.punch(time(9, 0), "in")
+        self.punch(time(17, 0), "out")
+
+        day = self.compute()
+
+        self.assertEqual(day.late_min, 0)
+        self.assertEqual(day.anomalies.get("unpaired_out"), 1)
+        self.assertEqual(get_late_comers(self.day, self.day), [])
 
 
 class AutoClosureRegressionTests(AttendanceBase):


### PR DESCRIPTION
## Summary
- ignore attendance pairs flagged as unpaired_out when picking the first in/last out so stray out punches cannot affect lateness
- add a regression test to cover a stray out before the first real in and ensure the late-comers report stays empty

## Testing
- PYTHONPATH=$PWD pytest attendance/tests tests/test_attendance_rules.py::AutoEventSequenceAnomalyTests::test_stray_out_before_in_does_not_trigger_late

------
https://chatgpt.com/codex/tasks/task_e_68cd83b566c8832d8dd45ec02d114fd5