### PR TITLE
Add command to rectify late minutes with stray outs

### DIFF
--- a/attendance/management/commands/rectify_late_minutes.py
+++ b/attendance/management/commands/rectify_late_minutes.py
@@ -1,0 +1,134 @@
+from __future__ import annotations
+
+from datetime import date
+
+from django.core.management.base import BaseCommand, CommandError
+from django.db import transaction
+from django.db.models import Q
+from django.utils.dateparse import parse_date
+
+from attendance.models import AttDay, AttPair
+from attendance.services import build_pairs_for, compute_att_day
+
+
+class Command(BaseCommand):
+    """Recompute days where stray OUT punches inflated late minutes."""
+
+    help = "Rectify attendance days where stray OUT punches inflated late minutes"
+
+    def add_arguments(self, parser):
+        parser.add_argument("--start-date", required=True)
+        parser.add_argument("--end-date", required=True)
+        parser.add_argument("--employee-id", type=int, action="append", dest="employee_ids")
+        parser.add_argument("--company-id", type=int, action="append", dest="company_ids")
+        parser.add_argument("--batch-size", type=int, default=500)
+        parser.add_argument("--dry-run", action="store_true")
+        parser.add_argument("--no-input", action="store_true")
+
+    def handle(self, *args, **options):
+        start = parse_date(options["start_date"])
+        end = parse_date(options["end_date"])
+        if not start or not end or start > end:
+            raise CommandError("Invalid date range")
+
+        batch_size: int = options["batch_size"] or 500
+        if batch_size <= 0:
+            raise CommandError("batch-size must be a positive integer")
+
+        dry_run: bool = options["dry_run"]
+        no_input: bool = options["no_input"]
+        employee_ids = options.get("employee_ids") or []
+        company_ids = options.get("company_ids") or []
+
+        company_filter: Q | None = None
+        if company_ids:
+            company_filter = (
+                Q(employee__trade_license__company_id__in=company_ids)
+                | Q(employee__department__branch__company_id__in=company_ids)
+                | Q(employee__project__branch__company_id__in=company_ids)
+            )
+
+        day_qs = AttDay.objects.filter(date__gte=start, date__lte=end, late_min__gt=0)
+        if employee_ids:
+            day_qs = day_qs.filter(employee_id__in=employee_ids)
+        if company_filter is not None:
+            day_qs = day_qs.filter(company_filter)
+
+        candidate_days: dict[tuple[int, date], AttDay] = {
+            (day.employee_id, day.date): day for day in day_qs.iterator()
+        }
+
+        qs = AttPair.objects.filter(date__gte=start, date__lte=end)
+        if employee_ids:
+            qs = qs.filter(employee_id__in=employee_ids)
+        if company_filter is not None:
+            qs = qs.filter(company_filter)
+        qs = qs.order_by("employee_id", "date", "in_ts", "id")
+
+        total_pairs = qs.count()
+        self.stdout.write(
+            f"Scanning {total_pairs} attendance pairs between {start} and {end}"
+            f" (batch size {batch_size})"
+        )
+        if dry_run:
+            self.stdout.write("Running in dry-run mode; no changes will be applied.")
+        if not no_input:
+            confirm = input("Continue? [y/N]: ")
+            if confirm.lower() not in {"y", "yes"}:
+                self.stdout.write("Aborted.")
+                return
+
+        if not candidate_days:
+            self.stdout.write("No attendance days with positive late minutes were found.")
+
+        days_checked = 0
+        days_recomputed = 0
+        days_skipped = 0
+
+        current_key: tuple[int, date] | None = None
+        for pair in qs.iterator(chunk_size=batch_size):
+            key = (pair.employee_id, pair.date)
+            if key == current_key:
+                continue
+            current_key = key
+
+            day = candidate_days.get(key)
+            if not day:
+                continue
+
+            anomaly = pair.anomaly or {}
+            if "unpaired_out" not in anomaly:
+                continue
+
+            days_checked += 1
+            if day.locked:
+                self.stdout.write(
+                    f"Skipping locked day for employee {pair.employee_id} on {pair.date};"
+                    " leaving untouched."
+                )
+                days_skipped += 1
+                continue
+
+            message = (
+                "Would recompute" if dry_run else "Recomputing"
+            ) + (
+                f" attendance for employee {pair.employee_id} on {pair.date}"
+                f" (late_min={day.late_min})."
+            )
+            self.stdout.write(message)
+
+            if dry_run:
+                days_recomputed += 1
+                continue
+
+            with transaction.atomic():
+                build_pairs_for(pair.employee_id, pair.date)
+                compute_att_day(pair.employee_id, pair.date)
+            days_recomputed += 1
+
+        self.stdout.write("Summary:")
+        self.stdout.write(f"  Days checked: {days_checked}")
+        self.stdout.write(f"  Days recomputed: {days_recomputed}")
+        self.stdout.write(f"  Days skipped (locked): {days_skipped}")
+        if dry_run:
+            self.stdout.write("Dry run complete; no database writes were performed.")

--- a/tests/test_rectify_late_minutes_command.py
+++ b/tests/test_rectify_late_minutes_command.py
@@ -1,0 +1,174 @@
+from datetime import date, datetime, time
+from io import StringIO
+from unittest.mock import patch
+
+from django.core.management import call_command
+from django.test import TestCase
+from django.utils import timezone
+from zoneinfo import ZoneInfo
+
+from attendance.models import AttDay, AttPair
+from attendance.services import build_pairs_for, compute_att_day
+from capture.models import AttendanceDevice, PunchEvent
+from pagasys.models import Branch, Company, Department, Employee, RosterEntry, ShiftTemplate
+
+
+class RectifyLateMinutesCommandTests(TestCase):
+    def setUp(self):
+        tzname = timezone.get_current_timezone_name()
+        self.day = date(2024, 1, 2)
+        self.company = Company.objects.create(name="C1", timezone=tzname)
+        self.branch = Branch.objects.create(company=self.company, name="B1")
+        self.department = Department.objects.create(branch=self.branch, name="D1")
+        self.employee = Employee.objects.create(
+            username="emp",
+            first_name="E",
+            last_name="One",
+            department=self.department,
+            hire_date=self.day,
+            employment_type="permanent",
+            visa_type="personal",
+        )
+        self.device = AttendanceDevice.objects.create(
+            company=self.company,
+            name="dev1",
+            api_key="k1",
+        )
+        self.shift = ShiftTemplate.objects.create(
+            company=self.company,
+            name="Day",
+            start_time=time(9, 0),
+            end_time=time(17, 0),
+            grace_in_min=0,
+            grace_out_min=0,
+            break_minutes=0,
+        )
+        RosterEntry.objects.create(employee=self.employee, date=self.day, shift=self.shift)
+
+        self.tz = ZoneInfo(tzname)
+        self.pair_patch = patch("capture.signals.pair_employee_day_task.delay")
+        self.compute_patch = patch("capture.signals.compute_employee_day_task.delay")
+        self.pair_patch.start()
+        self.compute_patch.start()
+        self.addCleanup(self.pair_patch.stop)
+        self.addCleanup(self.compute_patch.stop)
+
+    def make_legacy_state(self):
+        stray_out = timezone.make_aware(
+            datetime.combine(self.day, time(8, 30)),
+            self.tz,
+        )
+        valid_in = timezone.make_aware(
+            datetime.combine(self.day, time(9, 0)),
+            self.tz,
+        )
+        valid_out = timezone.make_aware(
+            datetime.combine(self.day, time(17, 0)),
+            self.tz,
+        )
+
+        PunchEvent.objects.create(
+            device=self.device,
+            company=self.company,
+            employee=self.employee,
+            matched_employee=self.employee,
+            action="out",
+            device_ts=stray_out,
+            roster_date=self.day,
+            roster_fallback=False,
+        )
+        PunchEvent.objects.create(
+            device=self.device,
+            company=self.company,
+            employee=self.employee,
+            matched_employee=self.employee,
+            action="in",
+            device_ts=valid_in,
+            roster_date=self.day,
+            roster_fallback=False,
+        )
+        PunchEvent.objects.create(
+            device=self.device,
+            company=self.company,
+            employee=self.employee,
+            matched_employee=self.employee,
+            action="out",
+            device_ts=valid_out,
+            roster_date=self.day,
+            roster_fallback=False,
+        )
+
+        build_pairs_for(self.employee.id, self.day, self.shift)
+        compute_att_day(self.employee.id, self.day)
+
+        day = AttDay.objects.get(employee=self.employee, date=self.day)
+        day.late_min = 45
+        day.save(update_fields=["late_min"])
+        return day
+
+    def test_dry_run_reports_without_changes(self):
+        original_day = self.make_legacy_state()
+        output = StringIO()
+
+        call_command(
+            "rectify_late_minutes",
+            "--start-date",
+            str(self.day),
+            "--end-date",
+            str(self.day),
+            "--dry-run",
+            "--no-input",
+            stdout=output,
+        )
+
+        refreshed = AttDay.objects.get(pk=original_day.pk)
+        self.assertEqual(refreshed.late_min, 45)
+        first_pair = (
+            AttPair.objects.filter(employee=self.employee, date=self.day)
+            .order_by("in_ts")
+            .first()
+        )
+        self.assertIn("unpaired_out", first_pair.anomaly)
+        self.assertIn("Dry run", output.getvalue())
+
+    def test_live_run_resets_late_minutes(self):
+        self.make_legacy_state()
+
+        call_command(
+            "rectify_late_minutes",
+            "--start-date",
+            str(self.day),
+            "--end-date",
+            str(self.day),
+            "--no-input",
+        )
+
+        day = AttDay.objects.get(employee=self.employee, date=self.day)
+        self.assertEqual(day.late_min, 0)
+        self.assertEqual(day.anomalies.get("unpaired_out"), 1)
+        first_pair = (
+            AttPair.objects.filter(employee=self.employee, date=self.day)
+            .order_by("in_ts")
+            .first()
+        )
+        self.assertIn("unpaired_out", first_pair.anomaly)
+
+    def test_locked_day_is_skipped(self):
+        day = self.make_legacy_state()
+        AttDay.objects.filter(pk=day.pk).update(locked=True)
+
+        output = StringIO()
+        call_command(
+            "rectify_late_minutes",
+            "--start-date",
+            str(self.day),
+            "--end-date",
+            str(self.day),
+            "--no-input",
+            stdout=output,
+        )
+
+        refreshed = AttDay.objects.get(pk=day.pk)
+        self.assertTrue(refreshed.locked)
+        self.assertEqual(refreshed.late_min, 45)
+        self.assertIn("Skipping locked day", output.getvalue())


### PR DESCRIPTION
## Summary
- add a management command that reprocesses days whose earliest pair is an unpaired OUT and still has positive late minutes
- ensure locked days are skipped, dry-run mode reports changes, and live recomputes run inside transactions
- add regression coverage exercising dry-run, live recompute, and locked day behaviour for the new command

## Testing
- python manage.py test tests.test_rectify_late_minutes_command

------
https://chatgpt.com/codex/tasks/task_e_68cd871b864c832d921f019491d7d0a9