### PR TITLE
Align attendance day admin panels with change form container

### DIFF
--- a/attendance/templates/admin/attendance/attday/change_form.html
+++ b/attendance/templates/admin/attendance/attday/change_form.html
@@ -2,7 +2,46 @@
 {% load i18n %}
 
 {% block content %}
-    {{ block.super }}
+    <form {% if has_file_field %}enctype="multipart/form-data" {% endif %}action="{{ form_url }}" method="post" id="{{ opts.model_name }}_form" novalidate>{% csrf_token %}{% block form_top %}{% endblock %}
+        <div>
+            <!-- Popup Hidden Field -->
+            {% if is_popup %}<input type="hidden" name="_popup" value="1" />{% endif %}
+
+            <!-- No Submit-Row on Top -->
+
+            <!-- Errors -->
+            {% if errors %}
+                <p class="errornote">{% if errors|length == 1 %}{% trans "Please correct the error below." %}{% else %}{% trans "Please correct the errors below." %}{% endif %}</p>
+                <ul class="errorlist">{% for error in adminform.form.non_field_errors %}<li>{{ error }}</li>{% endfor %}</ul>
+            {% endif %}
+
+            <!-- Fieldsets -->
+            {% block field_sets %}
+                {% for fieldset in adminform %}
+                    {% include "admin/includes/fieldset.html" %}
+                {% endfor %}
+            {% endblock %}
+
+            {% block after_field_sets %}{% endblock %}
+
+            <!-- Inlines -->
+            {% block inline_field_sets %}
+                {% for inline_admin_formset in inline_admin_formsets %}
+                    {% include inline_admin_formset.opts.template %}
+                {% endfor %}
+            {% endblock %}
+
+            {% block after_related_objects %}{% endblock %}
+
+            <!-- Submit-Row -->
+            {% block submit_buttons_bottom %}{% submit_row %}{% endblock %}
+
+            <!-- JS for prepopulated fields -->
+            {% prepopulated_fields_js %}
+
+        </div>
+    </form>
+
     {% if roster_overview %}
         <div id="roster-overview-module" class="inline-group">
             <fieldset class="module aligned">
@@ -233,6 +272,7 @@
             {% endif %}
         </fieldset>
     </div>
+
     {% if quick_adjustment_form and quick_adjustment_url %}
         <div id="quick-adjustment-module" class="inline-group">
             <fieldset class="module aligned">


### PR DESCRIPTION
## Summary
- inline the Grappelli change-form markup so custom attendance panels share the same content container
- render roster, session, and punch summaries after the form while keeping the quick adjustment form outside the main change form

## Testing
- python manage.py check

------
https://chatgpt.com/codex/tasks/task_e_68ce345c48a8832d8f3ff48fd9a8d826