### PR TITLE
Ensure attendance change form template loads admin tags

### DIFF
--- a/attendance/templates/admin/attendance/attday/change_form.html
+++ b/attendance/templates/admin/attendance/attday/change_form.html
@@ -1,5 +1,5 @@
 {% extends "admin/change_form.html" %}
-{% load i18n %}
+{% load i18n admin_urls static admin_modify %}
 
 {% block content %}
     <form {% if has_file_field %}enctype="multipart/form-data" {% endif %}action="{{ form_url }}" method="post" id="{{ opts.model_name }}_form" novalidate>{% csrf_token %}{% block form_top %}{% endblock %}


### PR DESCRIPTION
## Summary
- load the standard Django admin template tags in the attendance day change form override so submit_row and prepopulated_fields_js are available

## Testing
- pytest -q --disable-warnings --maxfail=1 --splits 10 --group 1 -n auto --dist loadfile --testmon-noselect

------
https://chatgpt.com/codex/tasks/task_e_68ce372336d4832da0ca4ec07ab0a99b