### PR TITLE
Handle roster scoping for trade license employees

### DIFF
--- a/capture/tests/test_aws.py
+++ b/capture/tests/test_aws.py
@@ -26,21 +26,24 @@ def test_put_capture_to_s3_uploads_and_hashes(monkeypatch, settings):
             return dummy_s3
 
     monkeypatch.setattr(aws, "_get_session", lambda: DummySession())
-    fake_uuid = uuid.UUID("01234567-89ab-cdef-0123-456789abcdef")
-    monkeypatch.setattr(aws.uuid, "uuid4", lambda: fake_uuid)
-    monkeypatch.setattr(aws.timezone, "localdate", lambda: date(2023, 3, 4))
-    data = b"image bytes"
-    key, sha = aws.put_capture_to_s3(1, 2, data)
-    expected_key = (
-        "attendance-capture/"
-        "1/2/2023/03/04/"
-        "0123456789abcdef0123456789abcdef.jpg"
-    )
-    assert key == expected_key
-    assert sha == hashlib.sha256(data).hexdigest()
-    assert dummy_s3.calls == [
-        ("capturebucket", expected_key, data, "image/jpeg")
-    ]
+    try:
+        fake_uuid = uuid.UUID("01234567-89ab-cdef-0123-456789abcdef")
+        monkeypatch.setattr(aws.uuid, "uuid4", lambda: fake_uuid)
+        monkeypatch.setattr(aws.timezone, "localdate", lambda: date(2023, 3, 4))
+        data = b"image bytes"
+        key, sha = aws.put_capture_to_s3(1, 2, data)
+        expected_key = (
+            "attendance-capture/"
+            "1/2/2023/03/04/"
+            "0123456789abcdef0123456789abcdef.jpg"
+        )
+        assert key == expected_key
+        assert sha == hashlib.sha256(data).hexdigest()
+        assert dummy_s3.calls == [
+            ("capturebucket", expected_key, data, "image/jpeg")
+        ]
+    finally:
+        aws.reset_clients()
 
 
 def test_put_enroll_to_s3_uploads_and_hashes(monkeypatch, settings):
@@ -54,18 +57,21 @@ def test_put_enroll_to_s3_uploads_and_hashes(monkeypatch, settings):
             return dummy_s3
 
     monkeypatch.setattr(aws, "_get_session", lambda: DummySession())
-    fake_uuid = uuid.UUID("fedcba98-7654-3210-fedc-ba9876543210")
-    monkeypatch.setattr(aws.uuid, "uuid4", lambda: fake_uuid)
-    data = b"enroll image"
-    key, sha = aws.put_enroll_to_s3(3, 4, data)
-    expected_key = (
-        "attendance-enroll/3/4/fedcba9876543210fedcba9876543210.jpg"
-    )
-    assert key == expected_key
-    assert sha == hashlib.sha256(data).hexdigest()
-    assert dummy_s3.calls == [
-        ("enrollbucket", expected_key, data, "image/jpeg")
-    ]
+    try:
+        fake_uuid = uuid.UUID("fedcba98-7654-3210-fedc-ba9876543210")
+        monkeypatch.setattr(aws.uuid, "uuid4", lambda: fake_uuid)
+        data = b"enroll image"
+        key, sha = aws.put_enroll_to_s3(3, 4, data)
+        expected_key = (
+            "attendance-enroll/3/4/fedcba9876543210fedcba9876543210.jpg"
+        )
+        assert key == expected_key
+        assert sha == hashlib.sha256(data).hexdigest()
+        assert dummy_s3.calls == [
+            ("enrollbucket", expected_key, data, "image/jpeg")
+        ]
+    finally:
+        aws.reset_clients()
 
 
 def test_put_to_s3_requires_boto3(monkeypatch):
@@ -104,16 +110,19 @@ def test_search_face_by_image_retries_missing_collection(monkeypatch, settings):
             return client
 
     monkeypatch.setattr(aws, "_get_session", lambda: DummySession())
-    called = {}
+    try:
+        called = {}
 
-    def fake_ensure(cid):
-        called["cid"] = cid
+        def fake_ensure(cid):
+            called["cid"] = cid
 
-    monkeypatch.setattr(aws, "ensure_collection", fake_ensure)
-    resp = aws.search_face_by_image(3, b"img", 0.5)
-    assert client.calls == 2
-    assert called["cid"] == "pref-3"
-    assert resp["args"]["CollectionId"] == "pref-3"
+        monkeypatch.setattr(aws, "ensure_collection", fake_ensure)
+        resp = aws.search_face_by_image(3, b"img", 0.5)
+        assert client.calls == 2
+        assert called["cid"] == "pref-3"
+        assert resp["args"]["CollectionId"] == "pref-3"
+    finally:
+        aws.reset_clients()
 
 
 def test_search_face_by_image_no_retry_when_collection_exists(monkeypatch, settings):
@@ -140,16 +149,19 @@ def test_search_face_by_image_no_retry_when_collection_exists(monkeypatch, setti
             return client
 
     monkeypatch.setattr(aws, "_get_session", lambda: DummySession())
-    called = {}
+    try:
+        called = {}
 
-    def fake_ensure(cid):
-        called["cid"] = cid
+        def fake_ensure(cid):
+            called["cid"] = cid
 
-    monkeypatch.setattr(aws, "ensure_collection", fake_ensure)
-    resp = aws.search_face_by_image(3, b"img", 0.5)
-    assert client.calls == 1
-    assert "cid" not in called
-    assert resp["args"]["CollectionId"] == "pref-3"
+        monkeypatch.setattr(aws, "ensure_collection", fake_ensure)
+        resp = aws.search_face_by_image(3, b"img", 0.5)
+        assert client.calls == 1
+        assert "cid" not in called
+        assert resp["args"]["CollectionId"] == "pref-3"
+    finally:
+        aws.reset_clients()
 
 
 def test_clients_singleton(monkeypatch):

--- a/pagasys/policy/filters.py
+++ b/pagasys/policy/filters.py
@@ -80,7 +80,11 @@ class RosterFilter(df.FilterSet):
         return qs.filter(
             Q(employee__department__branch_id=value)
             | Q(employee__project__branch_id=value)
-            | Q(employee__trade_license__branches__id=value)
+            | Q(
+                employee__department__branch_id__isnull=True,
+                employee__project__branch_id__isnull=True,
+                employee__trade_license__branches__id=value,
+            )
         )
 
     class Meta:

--- a/pagasys/policy/permissions.py
+++ b/pagasys/policy/permissions.py
@@ -80,7 +80,9 @@ class CompanyScopedQuerysetMixin:
         if model is ShiftRule:
             return qs.filter(shift__company=company)
         if model is RosterEntry:
-            return qs.filter(employee_company_q(company, field_prefix="employee"))
+            return qs.filter(
+                employee_company_q(company, field_prefix="employee")
+            ).distinct()
         return qs
 
 BRANCH_MANAGER = "Branch Manager"

--- a/pagasys/tests/test_policy_api.py
+++ b/pagasys/tests/test_policy_api.py
@@ -193,6 +193,37 @@ class PolicyApiTests(TestCase):
         rest_days = sum(item["rest_days"] for item in resp.data)
         assert days == 2 and rest_days == 1
 
+    def test_roster_list_includes_trade_license_only_employee(self):
+        shift = ShiftTemplate.objects.create(
+            company=self.company,
+            name="Shift",
+            start_time="09:00",
+            end_time="17:00",
+        )
+        if connection.vendor != "sqlite":
+            self.skipTest("Test requires SQLite check-constraint override")
+        with connection.cursor() as cursor:
+            cursor.execute("PRAGMA ignore_check_constraints = ON")
+        try:
+            license_only = Employee.objects.create_user(
+                username="licensed", password="pass", trade_license=self.license,
+                department=None, project=None,
+                hire_date="2024-01-01", employment_type="permanent",
+                visa_type="company",
+            )
+        finally:
+            with connection.cursor() as cursor:
+                cursor.execute("PRAGMA ignore_check_constraints = OFF")
+        RosterEntry.objects.create(
+            employee=license_only,
+            date="2024-03-15",
+            shift=shift,
+        )
+        resp = self.client.get(f"/api/companies/{self.company.id}/roster/")
+        assert resp.status_code == 200
+        employees = [entry["employee"] for entry in resp.data["results"]]
+        assert license_only.id in employees
+
     def test_error_shape_from_bulk_upsert(self):
         resp = self.client.post(
             f"/api/companies/{self.company.id}/roster/bulk-upsert/",

--- a/pagasys/tests/test_roster_api.py
+++ b/pagasys/tests/test_roster_api.py
@@ -66,7 +66,7 @@ class RosterEntryApiTests(TestCase):
         # second branch and employee for branch filtering
         self.branch2 = Branch.objects.create(company=self.company, name="B2")
         dept2 = Department.objects.create(branch=self.branch2, name="D2")
-        user2 = Employee.objects.create_user(
+        self.user2 = Employee.objects.create_user(
             username="u2",
             password="pass",
             department=dept2,
@@ -76,7 +76,7 @@ class RosterEntryApiTests(TestCase):
             visa_type="company",
         )
         RosterEntry.objects.create(
-            employee=user2, shift=self.shift, date="2024-07-01"
+            employee=self.user2, shift=self.shift, date="2024-07-01"
         )
 
     def test_filter_date_range(self):
@@ -97,6 +97,19 @@ class RosterEntryApiTests(TestCase):
         resp = self.client.get(f"/api/roster-entries/?branch={self.branch2.id}")
         assert resp.status_code == 200
         assert len(resp.data["results"]) == 1
+
+    def test_filter_branch_prefers_assignment_over_license(self):
+        self.license.branches.add(self.branch2)
+        resp = self.client.get(f"/api/roster-entries/?branch={self.branch.id}")
+        assert resp.status_code == 200
+        assert {entry["employee"] for entry in resp.data["results"]} == {
+            self.user.id
+        }
+        resp = self.client.get(f"/api/roster-entries/?branch={self.branch2.id}")
+        assert resp.status_code == 200
+        assert {entry["employee"] for entry in resp.data["results"]} == {
+            self.user2.id
+        }
 
     def test_ordering(self):
         resp = self.client.get("/api/roster-entries/?ordering=-date")

--- a/pagasys/tests/test_scoping.py
+++ b/pagasys/tests/test_scoping.py
@@ -3,6 +3,7 @@ from datetime import date, time
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import Group
 from django.core.management import call_command
+from django.db import connection
 from django.test import TestCase
 
 from rest_framework.request import Request
@@ -70,6 +71,12 @@ class CompanyScopedQuerysetTests(TestCase):
         admin_group = Group.objects.get(name="Company Admin")
         self.company_admin.groups.add(admin_group)
 
+        self.company_license = TradeLicense.objects.create(
+            company=self.company,
+            license_no="COMP-LIC-001",
+            max_visas=5,
+        )
+
         self.department_employee = self.User.objects.create_user(
             username="dept-emp",
             password="pass",
@@ -94,6 +101,24 @@ class CompanyScopedQuerysetTests(TestCase):
             employment_type="permanent",
             visa_type="personal",
         )
+        self.trade_license_employee = None
+        if connection.vendor == "sqlite":
+            with connection.cursor() as cursor:
+                cursor.execute("PRAGMA ignore_check_constraints = ON")
+            try:
+                self.trade_license_employee = self.User.objects.create_user(
+                    username="license-emp",
+                    password="pass",
+                    hire_date=date(2024, 1, 5),
+                    employment_type="permanent",
+                    visa_type="company",
+                    trade_license=self.company_license,
+                    department=None,
+                    project=None,
+                )
+            finally:
+                with connection.cursor() as cursor:
+                    cursor.execute("PRAGMA ignore_check_constraints = OFF")
 
         self.department_roster = RosterEntry(
             employee=self.department_employee,
@@ -119,6 +144,16 @@ class CompanyScopedQuerysetTests(TestCase):
         self.other_roster.full_clean()
         self.other_roster.save()
 
+        self.license_roster = None
+        if self.trade_license_employee:
+            self.license_roster = RosterEntry(
+                employee=self.trade_license_employee,
+                shift=self.shift,
+                date=date(2024, 1, 13),
+            )
+            self.license_roster.full_clean()
+            self.license_roster.save()
+
         self.factory = APIRequestFactory()
         self.company_view = type("View", (), {"kwargs": {"company_id": str(self.company.id)}})()
         self.other_company_view = type(
@@ -143,16 +178,20 @@ class CompanyScopedQuerysetTests(TestCase):
         view.action = "list"
         return view.filter_queryset(view.get_queryset())
 
-    def test_company_admin_sees_department_and_project_employees(self):
+    def test_company_admin_sees_department_project_and_license_employees(self):
         qs = scope_queryset(self.User.objects.all(), self.company_admin)
         self.assertIn(self.department_employee, qs)
         self.assertIn(self.project_employee, qs)
+        if self.trade_license_employee:
+            self.assertIn(self.trade_license_employee, qs)
         self.assertNotIn(self.other_employee, qs)
 
     def test_company_admin_sees_roster_entries_for_all_assignments(self):
         qs = scope_queryset(RosterEntry.objects.all(), self.company_admin)
         self.assertIn(self.department_roster, qs)
         self.assertIn(self.project_roster, qs)
+        if self.license_roster:
+            self.assertIn(self.license_roster, qs)
         self.assertNotIn(self.other_roster, qs)
 
     def test_company_admin_roster_api_includes_trade_license_conflict(self):
@@ -177,6 +216,8 @@ class CompanyScopedQuerysetTests(TestCase):
             self.department_employee,
             self.project_employee,
         }
+        if self.trade_license_employee:
+            expected.add(self.trade_license_employee)
         self.assertSetEqual(
             set(self.User.objects.filter(employee_company_q(self.company))),
             expected,
@@ -185,6 +226,22 @@ class CompanyScopedQuerysetTests(TestCase):
             set(self.User.objects.filter(employee_company_q(self.company.id))),
             expected,
         )
+
+    def test_company_admin_roster_api_includes_trade_license_employee(self):
+        if not self.license_roster:
+            self.skipTest(
+                "Requires SQLite constraint override to create trade-licence-only employee"
+            )
+        qs = self._roster_queryset_for(self.company_admin)
+        self.assertIn(self.license_roster, qs)
+
+    def test_company_admin_employee_api_includes_trade_license_employee(self):
+        if not self.trade_license_employee:
+            self.skipTest(
+                "Requires SQLite constraint override to create trade-licence-only employee"
+            )
+        qs = self._employee_queryset_for(self.company_admin)
+        self.assertIn(self.trade_license_employee, qs)
 
     def test_employee_company_ignores_trade_license_when_assignment_present(self):
         mismatch_license = TradeLicense.objects.create(

--- a/pagasys/utils.py
+++ b/pagasys/utils.py
@@ -146,16 +146,23 @@ def scope_queryset(queryset, user):
         if role == "branch_manager" and branch:
             if company_scope is None:
                 return queryset.none()
+            licence_scope = (
+                models.Q(department__isnull=True)
+                & models.Q(project__isnull=True)
+                & (
+                    models.Q(trade_license__branches=branch)
+                    | (
+                        models.Q(trade_license__branches__isnull=True)
+                        & models.Q(trade_license__company=branch.company)
+                    )
+                )
+            )
             return (
                 queryset.filter(employee_company_q(company_scope))
                 .filter(
                     models.Q(department__branch=branch)
                     | models.Q(project__branch=branch)
-                    | models.Q(trade_license__branches=branch)
-                    | (
-                        models.Q(trade_license__branches__isnull=True)
-                        & models.Q(trade_license__company=branch.company)
-                    )
+                    | licence_scope
                 )
                 .distinct()
             )
@@ -195,14 +202,21 @@ def scope_queryset(queryset, user):
         if role in ("company_admin", "payroll_manager"):
             return queryset
         if role == "branch_manager" and branch:
+            licence_scope = (
+                models.Q(employee__department__isnull=True)
+                & models.Q(employee__project__isnull=True)
+                & (
+                    models.Q(employee__trade_license__branches=branch)
+                    | (
+                        models.Q(employee__trade_license__branches__isnull=True)
+                        & models.Q(employee__trade_license__company=branch.company)
+                    )
+                )
+            )
             return queryset.filter(
                 models.Q(employee__department__branch=branch)
                 | models.Q(employee__project__branch=branch)
-                | models.Q(employee__trade_license__branches=branch)
-                | (
-                    models.Q(employee__trade_license__branches__isnull=True)
-                    & models.Q(employee__trade_license__company=branch.company)
-                )
+                | licence_scope
             ).distinct()
         if role == "department_manager" and user.department:
             return queryset.filter(employee__department=user.department)

--- a/pagasys/utils.py
+++ b/pagasys/utils.py
@@ -59,9 +59,16 @@ def employee_company_q(company_or_id, *, field_prefix=""):
     if company_id is None:
         return models.Q(pk__in=[])
     prefix = f"{field_prefix}__" if field_prefix else ""
-    return models.Q(**{f"{prefix}department__branch__company_id": company_id}) | models.Q(
-        **{f"{prefix}project__branch__company_id": company_id}
-    )
+    lookups = [
+        f"{prefix}department__branch__company_id",
+        f"{prefix}project__branch__company_id",
+        f"{prefix}trade_license__company_id",
+        f"{prefix}trade_license__branches__company_id",
+    ]
+    company_q = models.Q()
+    for path in lookups:
+        company_q |= models.Q(**{path: company_id})
+    return company_q
 
 
 def user_role(user):
@@ -131,13 +138,26 @@ def scope_queryset(queryset, user):
     if model is Employee:
         if not user.is_superuser:
             queryset = queryset.filter(is_superuser=False)
+        company_scope = company or getattr(branch, "company", None)
         if role in ("company_admin", "payroll_manager"):
-            if company:
-                return queryset.filter(employee_company_q(company))
+            if company_scope:
+                return queryset.filter(employee_company_q(company_scope)).distinct()
             return queryset.none()
         if role == "branch_manager" and branch:
-            return queryset.filter(
-                models.Q(department__branch=branch) | models.Q(project__branch=branch)
+            if company_scope is None:
+                return queryset.none()
+            return (
+                queryset.filter(employee_company_q(company_scope))
+                .filter(
+                    models.Q(department__branch=branch)
+                    | models.Q(project__branch=branch)
+                    | models.Q(trade_license__branches=branch)
+                    | (
+                        models.Q(trade_license__branches__isnull=True)
+                        & models.Q(trade_license__company=branch.company)
+                    )
+                )
+                .distinct()
             )
         if role == "department_manager" and user.department:
             return queryset.filter(department=user.department)
@@ -166,13 +186,24 @@ def scope_queryset(queryset, user):
         return queryset.none()
 
     if model is RosterEntry:
-        if role in ("company_admin", "payroll_manager") and company:
-            return queryset.filter(employee_company_q(company, field_prefix="employee"))
+        company_scope = company or getattr(branch, "company", None)
+        if company_scope is None:
+            return queryset.none()
+        queryset = queryset.filter(
+            employee_company_q(company_scope, field_prefix="employee")
+        ).distinct()
+        if role in ("company_admin", "payroll_manager"):
+            return queryset
         if role == "branch_manager" and branch:
             return queryset.filter(
                 models.Q(employee__department__branch=branch)
                 | models.Q(employee__project__branch=branch)
-            )
+                | models.Q(employee__trade_license__branches=branch)
+                | (
+                    models.Q(employee__trade_license__branches__isnull=True)
+                    & models.Q(employee__trade_license__company=branch.company)
+                )
+            ).distinct()
         if role == "department_manager" and user.department:
             return queryset.filter(employee__department=user.department)
         if role == "project_manager" and user.project:


### PR DESCRIPTION
## Summary
- extend `employee_company_q` to include trade license relationships so helpers resolve licence-linked staff
- ensure roster scoping reuses the helper and supports branch managers seeing licence-covered employees
- add a regression test confirming a licence-only employee appears in the company roster listing

## Testing
- python manage.py test pagasys.tests.test_policy_api.PolicyApiTests.test_roster_list_includes_trade_license_only_employee


------
https://chatgpt.com/codex/tasks/task_e_68d626a31b40832d9e90ecc9075d6b9e